### PR TITLE
Added all of the traits listed in the Discworld RPG

### DIFF
--- a/Library/Discworld Roleplaying Game/Traits/Discworld Roleplaying Game Traits.adq
+++ b/Library/Discworld Roleplaying Game/Traits/Discworld Roleplaying Game Traits.adq
@@ -1,0 +1,11465 @@
+{
+	"type": "trait_list",
+	"version": 4,
+	"rows": [
+		{
+			"id": "4086e16f-94b1-4149-94e0-b3d346755033",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "d660d620-c190-4078-abcb-4bb0728a7eb8",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "39b6cea6-9952-4f5a-965c-3b1ddf203667",
+							"type": "trait",
+							"name": "Decreased Dexterity",
+							"reference": "DW26",
+							"levels": 1,
+							"points_per_level": -20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "dx",
+									"amount": -1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": -20
+							}
+						},
+						{
+							"id": "0d31892d-acd7-43ee-874a-79bbb25572a9",
+							"type": "trait",
+							"name": "Increased Dexterity",
+							"reference": "DW26",
+							"levels": 1,
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "dx",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 20
+							}
+						}
+					],
+					"name": "Dexterity",
+					"userdesc": "Dexterity measures agility, coordination, and fine motor ability. It controls your basic ability at athletics and combat, and at craft skills that call for a delicate touch. DX also helps determine Basic Speed (p. 28) and Basic Move (p. 28). \nQuadrupeds (p. 96) buy DX at 40% off, or for 12 points/level, because they can do less with it.",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "53ffc584-385c-4e64-9df9-fbc9ec4a8f9e",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "b8b18e6a-5679-41d8-b99b-02d2ad2204d3",
+							"type": "trait",
+							"name": "Decreased Health",
+							"reference": "DW27",
+							"levels": 1,
+							"points_per_level": -10,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "ht",
+									"amount": -1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "97f77b30-5b3a-4d33-8bad-9fb5e484f915",
+							"type": "trait",
+							"name": "Increased Health",
+							"reference": "DW27",
+							"levels": 1,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "ht",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 10
+							}
+						}
+					],
+					"name": "Health",
+					"userdesc": "Health represents energy, vitality, stamina, resistance (to poison, disease, etc.), and basic “grit.” High HT is good for anyone and vital for barbarian warriors. HT determines Fatigue Points (below) and helps determine Basic Speed (p. 28) and Basic Move (p. 28).",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "1b236515-74a5-43fc-817a-c4e79e0e22bc",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "a30a34c7-d917-4830-8387-651824ea7373",
+							"type": "trait",
+							"name": "Decreased Intelligence",
+							"reference": "DW27",
+							"levels": 1,
+							"points_per_level": -20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": -1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": -20
+							}
+						},
+						{
+							"id": "e4d519cd-2cff-4f27-882e-612db1e46345",
+							"type": "trait",
+							"name": "Increased Intelligence",
+							"reference": "DW27",
+							"levels": 1,
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 20
+							}
+						}
+					],
+					"name": "Intelligence",
+					"userdesc": "Intelligence broadly measures brainpower, including creativity, intuition, memory, and reason. It rules your basic ability with “mental” skills: philosophy, negotiation, etc. Any wizard, strategist, or politician needs a high IQ. A creature with IQ less than 6 isn’t “sapient” – it can’t learn to talk or acquire technological skills (p. 69). The secondary characteristics of Will (below) and Perception (below) are based on IQ.\nIntelligence comes in many forms, which may be reflected by advantages, disadvantages, and skills. The Patrician, Archchancellor Ridcully, and Leonard of Quirm all have high intelligence, but apply it very differently!",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "d6babe39-bf34-4658-87a1-22910d02c25a",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "f0b12dbe-bdd7-4b02-a530-d62995c0c513",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "c274cbfb-8a71-4563-9975-790e8f360130",
+									"type": "trait",
+									"name": "Decreased Basic Move",
+									"reference": "DW28",
+									"levels": 1,
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "basic_move",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "34c5cfb0-dd70-4990-bd24-475b0809c17a",
+									"type": "trait",
+									"name": "Increased Basic Move",
+									"reference": "DW28",
+									"levels": 1,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "basic_move",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 5
+									}
+								}
+							],
+							"name": "Basic Move",
+							"userdesc": "Basic Move is how fast you can run. It’s your usual ground speed in yards per second (you can go a little faster if you “sprint” in a straight line; see Running, p. 168). Basic Move starts equal to Basic Speed, less any fractions; e.g., Basic Speed 5.75 gives Basic Move 5. An average person has Basic Move 5; therefore, he can run about five yards per second if unencumbered.",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "f9d93a9c-3569-402e-b5db-e21899c7ebb5",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "ffeb414d-6283-4ec4-8976-421febf7422d",
+									"type": "trait",
+									"name": "Decreased Basic Speed",
+									"reference": "DW28",
+									"levels": 1,
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "basic_speed",
+											"amount": -0.25,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "18b6913b-495e-47aa-bf30-3cb4189ddbac",
+									"type": "trait",
+									"name": "Increased Basic Speed",
+									"reference": "DW28",
+									"levels": 1,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "basic_speed",
+											"amount": 0.25,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 5
+									}
+								}
+							],
+							"name": "Basic Speed",
+							"userdesc": "Basic Speed gauges your reflexes and general physical quickness. It helps determine your running speed, your chance of dodging an attack, and the order in which you act in combat (a high Basic Speed lets you “out-react” your foes). To calculate starting Basic Speed, add your HT and DX together, and then divide the total by 4. Do not round it off. A 5.25 is better than a 5!\n\nDodge: Your Dodge defence (see Dodging, p. 180) equals Basic Speed + 3, dropping all fractions. For instance, if your Basic Speed is 5.25, your Dodge is 8.",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "02cd5921-56dd-4f77-851b-4744acbea08a",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "1ac3ff0c-20f3-4345-84b9-09ccc8696e45",
+									"type": "trait",
+									"name": "Extra Fatigue Points",
+									"reference": "DW27",
+									"levels": 1,
+									"points_per_level": 3,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "fp",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 3
+									}
+								},
+								{
+									"id": "3bfa7c3f-3cbd-4826-819c-0598886cea76",
+									"type": "trait",
+									"name": "Fewer Fatigue Points",
+									"reference": "DW27",
+									"levels": 1,
+									"points_per_level": -3,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "fp",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": -3
+									}
+								}
+							],
+							"name": "Fatigue Points",
+							"userdesc": "Fatigue Points represent your body’s “energy supply.” You start with FP equal to your HT.",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "572bc1cc-0274-430e-afd7-759dd575c816",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "3a9b003b-c0bc-4aa7-b38f-aa6ebeb6affe",
+									"type": "trait",
+									"name": "Extra Hit Points",
+									"reference": "DW27",
+									"modifiers": [
+										{
+											"id": "910bfd80-869d-46d8-aa30-5c7c5bae59a4",
+											"type": "modifier",
+											"name": "Size",
+											"cost": -10,
+											"levels": 1,
+											"disabled": true
+										}
+									],
+									"levels": 1,
+									"points_per_level": 2,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "hp",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 2
+									}
+								},
+								{
+									"id": "73f8ea59-f328-492a-9c48-1d9a0ccf9432",
+									"type": "trait",
+									"name": "Fewer Hit Points",
+									"reference": "DW27",
+									"levels": 1,
+									"points_per_level": -2,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "hp",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": -2
+									}
+								}
+							],
+							"name": "Hit Points",
+							"userdesc": "Hit Points represent your body’s ability to sustain injury. You start with HP equal to your ST; e.g., ST 10 gives 10 HP. As with ST, you get a discount on the point cost of HP if you’re exceptionally large; see Character Size.",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "e9aab2a6-c22e-4514-9573-1ea825186b03",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "7f298ad4-6dd0-4006-978d-1bf216882268",
+									"type": "trait",
+									"name": "Decreased Perception",
+									"reference": "DW27",
+									"levels": 1,
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "0013fdaa-42a9-41d9-a54d-dce964590647",
+									"type": "trait",
+									"name": "Increased Perception",
+									"reference": "DW27",
+									"levels": 1,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 5
+									}
+								}
+							],
+							"name": "Perception",
+							"userdesc": "Perception rates your general alertness. The GM makes a “Sense roll” against your Per to determine whether you notice something. Per starts equal to IQ.",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "23df7926-32c2-4e04-b1c6-9906f2b45d9b",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "ef895c69-8ede-4853-a3f0-829bf8854ffd",
+									"type": "trait",
+									"name": "Decreased Will",
+									"reference": "DW27",
+									"levels": 1,
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "will",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "afe3440f-2f24-4593-8272-f6014f21bd9d",
+									"type": "trait",
+									"name": "Increased Will",
+									"reference": "DW27",
+									"levels": 1,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "will",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 5
+									}
+								}
+							],
+							"name": "Will",
+							"userdesc": "Will measures your ability to withstand psychological stress (brainwashing, fear, hypnotism, interrogation, seduction, torture, etc.) and your resistance to certain exotic attacks (e.g., elven mind-bending). It starts equal to IQ. Will doesn’t represent physical resistance – buy HT for that!",
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"name": "Secondary Charateristics",
+					"userdesc": "“Secondary characteristics” are quantities calculated from your attributes. You can raise or lower these by adjusting your attributes – or independently, if the GM permits. The latter is optional because it complicates the game. Regardless, normal humans rarely have scores more than about three levels different from their base values, or maybe a bit more for special cases (a couple of extra HP for someone who’s overweight, say – or almost anything for an Igor, to represent Igor engineering).\nSize Modifier (see below) is often listed with secondary characteristics for convenience, but it isn’t modified with points.",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "93aa29e5-d981-497b-9ff2-b86e9cbabdb8",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "3100694d-88e7-4ff2-89c4-4b46a7b15f17",
+							"type": "trait",
+							"name": "Decreased Strength",
+							"reference": "DW26",
+							"levels": 1,
+							"points_per_level": -10,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "st",
+									"amount": -1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "e0ba205c-92f7-4597-aa9c-633a7062e576",
+							"type": "trait",
+							"name": "Increased Strength",
+							"reference": "DW26",
+							"levels": 1,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "st",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 10
+							}
+						}
+					],
+					"name": "Strength",
+					"userdesc": "Strength measures physical power and bulk. It’s crucial to oldfashioned warriors, as high ST lets you dish out and absorb more damage in hand-to-hand combat. Any professional adventurer will find ST useful for lifting and throwing things, moving quickly with a load, and so on.\nStrength is more “open-ended” than other attributes. Scores\ngreater than 20 are common among large or supernatural creatures, while tiny nonhumans often have low ST.\nLarger creatures purchase ST at a discount; see Character Size (p. 27). Quadrupeds (p. 96) buy it at 40% off because, lacking hands, they can do less with it. Both situations might pertain, but no one can ever get ST at more than 80% off in total (that is, for less than 2 points/level). These discounts don’t affect the amount you get back for ST less than 10. However, if your race’s normal ST is less than 10 and you have Quadruped, you do get 40% off the cost of ST above your racial base, even if it’s\nstill less than 10.",
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"name": "Basic Attributes",
+			"userdesc": "Four numbers called “attributes” define your basic abilities: Strength (ST), Dexterity (DX), Intelligence (IQ), and Health (HT).\nA score of 10 in any attribute is free, and it represents the human average. Higher scores cost points: 10 points to raise ST or HT by one level, 20 points to raise DX or IQ by one level. Similarly, scores lower than 10 have a negative cost: -10 points per level for ST or HT, -20 points per level for DX or IQ. (Remember that negative point values mean you get those points back to spend elsewhere!)\nMost characters have attributes in the 1-20 range, and most normal humans have scores in the 8-12 range. Scores above 20 are possible but typically reserved for superhuman beings – ask the GM before buying such a value. At the other end of the scale, 1 is the minimum score for a human. Your decisions here will determine your most fundamental strengths and weaknesses throughout the game. Choose wisely:\n\n6 or less: Crippling. An attribute this bad severely constrains your lifestyle.\n7: Poor. Your limitations are immediately obvious to anyone who meets you. This is the lowest score you can have and still pass for “able-bodied.”\n8 or 9: Below average. Such scores are limiting but within the human norm. The GM may forbid attributes below 8 to adventurers in traditional high-action games.\n10: Average. Most humans get by just fine with a score of 10!\n11 or 12: Above average. These scores are superior but within the human norm.\n13 or 14: Exceptional. The attribute is immediately apparent – as bulging muscles, feline grace, witty dialogue, or glowing health – to those who meet you.\n15 or more: Amazing. An attribute this high draws constant comment and probably guides your career choices. \n\nThese guidelines suit humans and most other beings living in human society, though nonhumans may adjust them somewhat; e.g., trolls can easily possess truly superhuman Strength. See Rolling the Dice (pp. 165-167) for how attribute scores are used in play.",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "aab3ee34-56d3-4c35-bccb-eae8d36b75c7",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "e1744d7a-8fb9-49bb-8361-0ad09c2562b9",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "2ee5a6b3-c524-4059-a248-d6ca80d7ad34",
+							"type": "trait",
+							"name": "Attractive",
+							"reference": "DW29",
+							"userdesc": "You don’t enter beauty contests, but are definitely good-looking. Gives +1 on reaction rolls",
+							"base_points": 4,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 4
+							}
+						},
+						{
+							"id": "44bae406-9b13-4164-9bb1-d4d29def8380",
+							"type": "trait",
+							"name": "Average",
+							"reference": "DW29",
+							"userdesc": "The default level",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "8cfe1f07-a0d5-4e54-af6c-d4d8514d9c14",
+							"type": "trait",
+							"name": "Handsome (or Beautiful)",
+							"reference": "DW29",
+							"userdesc": "You could enter beauty contests. Gives +4 on reaction rolls made by those attracted to members of your sex, +2 from everyone else",
+							"base_points": 8,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"calc": {
+								"points": 8
+							}
+						},
+						{
+							"id": "008fc5c4-344d-42f0-9524-ce58b666d4da",
+							"type": "trait",
+							"name": "Hideous",
+							"reference": "DW28",
+							"userdesc": "Any sort of disgusting looks: severe skin disease, walleye . . . preferably several things at once. This gives -4 on reaction rolls.",
+							"base_points": -16,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"calc": {
+								"points": -16
+							}
+						},
+						{
+							"id": "38c756e0-1567-4557-b7f3-7d79fcd6a62d",
+							"type": "trait",
+							"name": "Ugly",
+							"reference": "DW28",
+							"userdesc": "As above, but not so bad – maybe only stringy hair and snaggle teeth. Gives -2 on reaction rolls",
+							"base_points": -8,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"calc": {
+								"points": -8
+							}
+						},
+						{
+							"id": "0042f70f-25e5-4ae6-bd51-da3868425d3d",
+							"type": "trait",
+							"name": "Unattractive",
+							"reference": "DW28",
+							"userdesc": "You look vaguely unappealing, but it’s nothing anyone can put a finger on. Gives -1 on reaction rolls",
+							"base_points": -4,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": -4
+							}
+						},
+						{
+							"id": "ba1bb59c-24a2-43c0-b9f9-339ccf7370a9",
+							"type": "trait",
+							"name": "Very Handsome (or Very Beautiful)",
+							"reference": "DW29",
+							"userdesc": "You could regularly win beauty contests. Gives +6 on reaction rolls made by those attracted to members of your sex, +2 from others.",
+							"base_points": 16,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"calc": {
+								"points": 16
+							}
+						}
+					],
+					"name": "Appearance",
+					"userdesc": "You may choose any physical appearance you like – it’s mostly a “special effect.” However, looks good or bad enough to influence how people respond to you have a point value, for which purpose appearance is rated in levels. Most people are “Average,” for 0 points. Pleasing looks give a bonus to reaction rolls (pp. 171- 172), and are an advantage that costs points. Unappealing looks give a reaction penalty, making them a disadvantage that gives back points\n\nThese reaction modifiers only influence people who can see you. For this purpose, “people” means your species and other species that happen to share the same aesthetics. For rules on how different species view each other, and what this means for characters, see Racial and Personal Appearance (p. 85).",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "6fd94e41-4100-4ea6-b1c0-e4b224246e4c",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "f2448d3c-52d7-4a9e-807e-89d90b8d5d8a",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "d8213c9a-3e30-4f98-b9d9-9e5b6ba339ab",
+									"type": "trait",
+									"name": "Dwarfism",
+									"reference": "DW29",
+									"userdesc": "-2 to those skills. You also have -1 Size Modifier relative to the norm for adults of your species (see Character Size, p. 27), and -1 to Basic Move (short legs). In combat, your reach (pp. 176-177) with any weapon is reduced by one yard (to a minimum of C), because you have shorter arms and related problems with your build. This is a personal physical abnormality, and it has nothing to do with the race of dwarfs; indeed, it would be possible to be a dwarf with dwarfism. Humans with dwarfism will always be less than 4’4” tall.",
+									"base_points": -15,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "basic_move",
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -2
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "sm",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -15
+									}
+								},
+								{
+									"id": "8ef3cb78-83cc-4ad6-8d17-62a4fe4e2cf9",
+									"type": "trait",
+									"name": "Gigantism",
+									"reference": "DW29",
+									"userdesc": " -2 to those skills. You also have +1 Size Modifier relative to the norm for your species (see Character Size, p. 27), possibly giving you a discount on your ST and HP, and you get +1 to Basic Move (long legs).",
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "basic_move",
+											"amount": 1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"specialization": {
+												"compare": "is_not",
+												"qualifier": "animals"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -2
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "sm",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 0
+									}
+								}
+							],
+							"name": "Height",
+							"userdesc": "In addition, Dwarfism and Gigantism affect some equipment costs; see Unusual Sizes and Shapes (p. 161).",
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "a56f9c5e-3acc-448e-aa7a-70f6e15a28c1",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "dd6d64f2-f96d-4f5c-9abf-75f87e8ade97",
+									"type": "trait",
+									"name": "Fat",
+									"reference": "DW29",
+									"userdesc": "-2 to those skills. However, you get +3 to Swimming rolls, and +2 to ST to resist knockback. Your HT may not exceed 15.",
+									"base_points": -3,
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "attribute_prereq",
+												"has": true,
+												"qualifier": {
+													"compare": "at_most",
+													"qualifier": 15
+												},
+												"which": "ht"
+											}
+										]
+									},
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "swimming"
+											},
+											"amount": 3
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to ST vs knockback",
+											"amount": 2
+										}
+									],
+									"calc": {
+										"points": -3
+									}
+								},
+								{
+									"id": "aa5304e1-2b28-436f-94e2-5e4fa6902f79",
+									"type": "trait",
+									"name": "Overweight",
+									"reference": "DW29",
+									"userdesc": "-1 to those skills. However, you get +1 to Swimming rolls, and +1 to ST to resist knockback.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "swimming"
+											},
+											"amount": 1
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to ST vs. knockback",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "52a23dbe-dea0-4b79-8b6a-e3baf722938e",
+									"type": "trait",
+									"name": "Skinny",
+									"reference": "DW29",
+									"userdesc": "-2 to those skills, and -2 to ST when you resist knockback (p. 186). Your HT may not exceed 14.",
+									"base_points": -5,
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "attribute_prereq",
+												"has": true,
+												"qualifier": {
+													"compare": "at_most",
+													"qualifier": 14
+												},
+												"which": "ht"
+											}
+										]
+									},
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to ST vs. knockback",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "55807c60-d495-413d-a90a-0b5fb16d73ac",
+									"type": "trait",
+									"name": "Very Fat",
+									"reference": "DW29",
+									"userdesc": "-3 to those skills. However, you get +5 to Swimming rolls, and +3 to ST to resist knockback. Your HT may not exceed 13.",
+									"base_points": -5,
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "attribute_prereq",
+												"has": true,
+												"qualifier": {
+													"compare": "at_most",
+													"qualifier": 13
+												},
+												"which": "ht"
+											}
+										]
+									},
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -3
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -3
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "swimming"
+											},
+											"amount": 5
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to ST vs knockback",
+											"amount": 3
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								}
+							],
+							"name": "Weight",
+							"calc": {
+								"points": -14
+							}
+						}
+					],
+					"name": "Build",
+					"userdesc": "If your physique differs significantly from the norm, you suffer penalties to your Disguise skill, and to Shadowing skill if trying to follow someone in a crowd. There are usually other consequences, too.",
+					"calc": {
+						"points": -29
+					}
+				},
+				{
+					"id": "af7d1b27-0448-40a3-8481-0cc3ded38ac2",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "c7beef7d-5570-4c7d-a8c4-1cac4bf153c5",
+							"type": "trait",
+							"name": "Disturbing Voice",
+							"reference": "DW30",
+							"base_points": -10,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "voice"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "diplomacy"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fast-talk"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "performance"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "public speaking"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "sex appeal"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "singing"
+									},
+									"amount": -2
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "6e674505-1e6c-4af4-98c0-1cf2ef8b4ce5",
+							"type": "trait",
+							"name": "Voice",
+							"reference": "DW30",
+							"base_points": 10,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "diplomacy"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fast-talk"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "mimicry"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "performance"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "politics"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "public speaking"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "sex appeal"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "singing"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others who can hear your voice",
+									"amount": 2
+								}
+							],
+							"calc": {
+								"points": 10
+							}
+						}
+					],
+					"name": "Vocal Fetures",
+					"userdesc": "You may have a notably good or bad voice. This modifies reaction rolls when you have to talk to people, and it affects the skills Diplomacy, Fast-Talk, Mimicry, Performance, Politics, Public Speaking, Sex Appeal, and Singing.",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "0f91b6f8-8947-4356-bed5-de6cef30c4d0",
+					"type": "trait",
+					"name": "Charisma",
+					"reference": "DW29",
+					"userdesc": "You have a natural ability to impress and lead others. Anyone can acquire a semblance through looks, manners, and intelligence, but real charisma is independent of these things. Each level gives +1 on all reaction rolls made by sapient beings with whom you actively interact (converse, lecture, etc.); +1 to Influence rolls (pp. 172-173); and +1 to Fortune-Telling, Leadership, Panhandling, and Public Speaking skills.",
+					"levels": 1,
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fortune-telling"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "leadership"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "panhandling"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from sapient being with whom you actively interact (converse, lecture, etc.)",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "to Influence rolls",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "afa1fc5f-84f2-403c-932a-bd865f3d8493",
+					"type": "trait",
+					"name": "Odious Personal Habit",
+					"reference": "DW29",
+					"notes": "@Habit: Barbarian Heroism, Throat-Staring@",
+					"userdesc": "You usually or always behave in a repugnant fashion. An Odious Personal Habit (OPH) is worth -5 points for every -1 to reaction rolls made by people who notice it. Specify the behaviour when you create your character, and work out the point value with the GM.",
+					"levels": 1,
+					"points_per_level": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from others",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "192b30df-acdd-4be1-9018-0f47e450548b",
+					"type": "trait",
+					"name": "Pitiable",
+					"reference": "DW29",
+					"userdesc": "Something about you makes people pity you and want to take care of you. You get +3 on reaction rolls from those who consider you to be in a position of weakness or need (which never includes those with the Callous disadvantage). Taken in conjunction with above-average looks, Pitiable means you’re “cute” instead of “sexy”; in combination with below-average looks, it means you’re “appealingly homely.”",
+					"base_points": 5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from those who consider you to be in a position of helplessness, weakness, or need (which never includes those with the Callous disadvantage)",
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "bd5b4c6a-c699-4916-ba0c-d06fd9ef0c3e",
+					"type": "trait",
+					"name": "Unnatural Features (@Description@)",
+					"reference": "DW30",
+					"userdesc": "You are superficially “normal” but have one or more disturbing cosmetic features. To qualify for points, these must be unnatural for your race. Grey, stony skin would be unnatural for a human, but not for troll! Specify the origin of your Unnatural Features: magical curse, bungled surgery, rare disease, etc. \nUnnatural Features need not be unattractive (if they are, you can also claim points for below-average Appearance), but they make it easy for others to identify you and hard for you to blend into a crowd. Each level, to a maximum of five levels, gives -1 to your Disguise and Shadowing skills, and +1 to others’ attempts to identify or follow you (including their Observation and Shadowing rolls), unless almost everyone else in the crowd happens to share your features.",
+					"levels": 1,
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": -1
+					}
+				}
+			],
+			"name": "Image, Looks, and Physique",
+			"userdesc": "Next, consider your character’s intrinsic “social” traits – appearance, manner, and bearing – and anything exceptional about his build. Traits with positive point values (e.g., aboveaverage Appearance, Voice) are considered advantages (p. 41) for all purposes. Those with negative point values (e.g., belowaverage Appearance, Odious Personal Habits) are deemed disadvantages (p. 53), and obey all the usual rules for such. Anything without a point value (e.g., height within the normal human range, handedness) merely adds “colour.”",
+			"calc": {
+				"points": -25
+			}
+		},
+		{
+			"id": "04c38a0a-5834-42cd-aa36-2ae7bd7d2c39",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "976a0635-bbd7-43c5-80f3-9a3e5a134504",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "aaa75f83-2362-4d93-a6f0-1cd0e356ce2a",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "8638a745-a993-40b3-b555-cc18352df5bc",
+									"type": "trait",
+									"name": "Language Talent",
+									"reference": "DW32",
+									"userdesc": "You’re naturally good at learning languages. When you learn one at a comprehension level above None, you automatically function at one level higher; thus, 4 points rather than the usual 6 gets you Native-level fluency and literacy in a foreign tongue. You also receive +1 to Shouting at Foreigners skill (p. 74).",
+									"base_points": 10,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "5d1d1a81-3f48-4927-9ced-18ed95f326d6",
+									"type": "trait",
+									"name": "Multilingual",
+									"reference": "DW32",
+									"userdesc": "You have enormous experience with languages, from years of study or extensive travel. You focus on one application of this knowledge – see Rincewind (pp. 330-332) and The Librarian (pp. 333-335) for examples – and may have the equivalent of a foreign accent when you’re out of practise with a specific tongue, although you shed this once you’ve had a chance to reimmerse yourself, and you can usually get by for any routine purposes. However, while your language ability is probably beyond anything possible in the dull reality of our own world, it isn’t supernatural. The GM can always rule that you haven’t had a chance to learn some language (especially if it’s a secret, long-forgotten, or from another universe), and can decide that you make occasional small mistakes whenever that would be funny. You may also have to spend a few seconds mentally switching gears when shifting between languages.",
+									"base_points": 20,
+									"calc": {
+										"points": 20
+									}
+								},
+								{
+									"id": "5131a34f-3d8a-479b-9f70-9c49b2d8ff7d",
+									"type": "trait",
+									"name": "Universal Translator",
+									"reference": "DW32",
+									"userdesc": "You can talk – and read, and write – any language you encounter, with Native-level fluency. This may involve one second of concentration as you switch tracks mentally, and it only works with one language at a time, but it is a supernatural advantage, normally limited to nonhuman beings. However, it’s the kind of thing which a powerful god might grant to a devout worshipper (the “gift of tongues”) to facilitate missionary work.",
+									"base_points": 30,
+									"calc": {
+										"points": 30
+									}
+								}
+							],
+							"name": "Language-Related Advantages",
+							"userdesc": "You may have special abilities involving languages:",
+							"calc": {
+								"points": 60
+							}
+						},
+						{
+							"id": "cc6ad7a9-0515-454a-8165-3818de292b10",
+							"type": "trait",
+							"name": "Language: @Language@",
+							"reference": "DW31",
+							"userdesc": "The point cost to learn an additional language depends on your “comprehension level” – a measure of how well you function in that language overall. There are four such levels:\n\nNone: You don’t know the language at all. 0 points.\nBroken: You know just enough to get by in daily life, but have -3 when using skills that depend on language. When reading, roll vs. IQ just to get the basic meaning. 1 point for spoken, 1 point for written.\nAccented: You can communicate clearly. You’re only at -1 when using skills that depend on language. 2 points for spoken, 2 points for written.\nNative: You use the language as well as a native. 3 points for spoken, 3 points for written\n\nSkill penalties are doubled (to -6 or -2) for artistic skills when beauty and subtlety are required; e.g., for composing poetry.\nNative-level comprehension of your native language is free. Being less literate in that language is a disadvantage: -1 point for Accented (a passable writing style, but with some bizarre spelling and punctuation), -2 points for Broken (sometimes called “semi-literacy”), or -3 points for None (illiteracy). Poor or nonexistent literacy is widespread in barbarian societies and among trolls, and the GM may choose not to count it against the campaign disadvantage limit (if any).\nWhen describing characters, assume by default that they write languages as well as they speak them; somebody described simply as having Klatchian (Accented) speaks and writes Klatchian at Accented level (and probably paid 4 points for this). If they don’t write as well as they speak, or vice versa, the description should give two levels; the first defines how well they speak the language, the second is how well they write it. For example, many trolls in Ankh-Morpork have Morporkian (Accented/None), for 2 points; they can chat quite well to locals, in distinctly trollish tones, but they’re completely illiterate in the language. A more complicated example might be somebody with Uberwaldian (Broken/Native), for 4 points; this person has perhaps learned to write fluent and chatty letters to acquaintances in Uberwald, but if he ever tries talking to them, he mangles the pronunciation and trips over his tongue.",
+							"modifiers": [
+								{
+									"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+									"type": "modifier",
+									"name": "Native",
+									"reference": "B23",
+									"cost": -6,
+									"cost_type": "points"
+								},
+								{
+									"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+									"type": "modifier",
+									"name": "Spoken (Broken)",
+									"reference": "B24",
+									"cost": 1,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+									"type": "modifier",
+									"name": "Spoken (Accented)",
+									"reference": "B24",
+									"cost": 2,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+									"type": "modifier",
+									"name": "Spoken (Native)",
+									"reference": "B24",
+									"cost": 3,
+									"cost_type": "points"
+								},
+								{
+									"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+									"type": "modifier",
+									"name": "Written (Broken)",
+									"reference": "B24",
+									"cost": 1,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+									"type": "modifier",
+									"name": "Written (Accented)",
+									"reference": "B24",
+									"cost": 2,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+									"type": "modifier",
+									"name": "Written (Native)",
+									"reference": "B24",
+									"cost": 3,
+									"cost_type": "points"
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"name": "Language",
+					"userdesc": "Most characters can read and write their native tongue. This costs no points, but you should note it under “Languages” on your character sheet; e.g., “Morporkian (Native) [0].” Additional competencies cost extra. For a discussion of languages on the Disc, see Languages (pp. 16-17). The PCs will typically need at least some grasp of Morporkian – but a lot depends on the game.",
+					"calc": {
+						"points": 60
+					}
+				},
+				{
+					"id": "11019aec-c62b-4fc5-b0aa-51e807ae086d",
+					"type": "trait_container",
+					"open": true,
+					"children": [
+						{
+							"id": "b184589b-eb68-4a42-afcf-756206bd032a",
+							"type": "trait",
+							"name": "High TL",
+							"reference": "DW31",
+							"userdesc": "Your personal TL is above the campaign standard. You may enter play with skills relating to equipment up to your personal TL. This is most useful if you also have access to high-TL equipment, but some high-tech knowledge can be useful in a low-tech setting even without. You may enter play with equipment from your background TL, with the GM’s permission, but its cost is doubled for each TL by which it exceeds the campaign standard (e.g., if TL4 gear is available in a basically TL2 game, it costs 4¥ the listed price); this reflects special import costs and the like. The GM may set some prices even higher, or simply prohibit certain equipment. You don’t start with more money than other characters merely because you have High TL, though – standard starting funds (p. 33) are determined purely by the setting’s TL.",
+							"levels": 1,
+							"points_per_level": 5,
+							"can_level": true,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "7d179f07-0745-4aff-a464-15a499e92afd",
+							"type": "trait",
+							"name": "Low TL",
+							"reference": "DW31",
+							"userdesc": "Your personal TL is below the campaign standard. You start with no knowledge (or default skills) relating to equipment above your personal TL. Even if a skill doesn’t have a /TL qualifier, the GM may rule that the necessary equipment wasn’t available in your home society (e.g., crossbows don’t exist before TL2, and fencing weapons don’t appear until TL4). You can learn DX-based technological skills (pertaining to vehicles, weapons, etc.) in play, but fundamental differences in thinking prevent you from learning IQ-based technological skills until you buy off this disadvantage. To prevent physically oriented characters from treating a level or two of Low TL as free points, the GM should rule that they’re confused by many details of higher-tech life, and hint that they’re being mocked as yokels behind their backs.",
+							"levels": 1,
+							"points_per_level": -5,
+							"can_level": true,
+							"calc": {
+								"points": -5
+							}
+						}
+					],
+					"name": "Personal Tech Level",
+					"userdesc": "Your personal TL may differ from the game average. A Hubland warrior wandering into Ankh-Morpork might not understand some of the devices (or ideas) he encounters, while a brilliant philosopher-inventor may actually be ahead of his surroundings. Hence, Low TL and High TL count as a disadvantage and an advantage, respectively.",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "649b3a69-d814-48a6-b1cf-4cd4adfaa224",
+					"type": "trait",
+					"name": "Cultural Familiarity (@Culture@)",
+					"reference": "DW32",
+					"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+					"userdesc": "A culture is a set of basic assumptions and ground rules for behaviour. In game terms, characters have no penalty to operate socially in cultures they understand – but in ones where they’re strangers, they’re in danger of making unfortunate or catastrophic errors, such as eating with the wrong hand or speaking to the wrong person. The Cultural Familiarity (CF) trait represents proper understanding of a culture. Each distinct culture has its own CF.\n\nCharacters are assumed to be comfortable with their “native” culture for free. Record this under “Cultural Familiarities”; e.g., “Klatchian [0].” Familiarity with other cultures costs 1 point per culture. If you don’t have CF for the culture in which you’re trying to operate, you’re at -3 to the skills Carousing, Dancing, Detect Lies, Diplomacy, Directing, Fast-Talk, Gesture, Heraldry, Leadership, Politics, Public Speaking, Savoir-Faire (all forms), Streetwise, and Teaching. This penalty extends to Acting if the GM decides that the act requires cultural background knowledge; to Criminology when dealing with criminal behaviour rather than methods; to Performance, Poetry, and anything else artistic when trying to emulate a local style; and to Intimidation and Sex Appeal when used as Influence skills (pp. 74-75).\n\nCultures are defined broadly; minor local differences don’t make a different culture. On the Disc, “contemporary” Cultural Familiarities include Sto Plains/Uberwald (covering everything from the Circle Sea through Ankh-Morpork to Lancre and beyond, and also such colonies and cultural outliers as Genua, Fourecks, and even Krull), Agatean (the formal, ancient culture of the Counterweight Continent), and Klatchian (actually the culture of the desert-dwelling peoples of the hubward edge of the great continent of Klatch, generally applicable in most neighbouring countries, too), along with surviving distinct local cultures in countless remote regions. Most adventurers should be able to get away with taking no more than two or three CFs, but those who want to spend long periods in remote communities may have to learn more – and games set in slightly earlier periods might feature distinct CFs for virtually every nationstate around the Circle Sea (Djelibeybi, Ephebe, Tsort, etc.).",
+					"modifiers": [
+						{
+							"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+							"type": "modifier",
+							"name": "Native",
+							"cost": -1,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				}
+			],
+			"name": "Social Background",
+			"userdesc": "Now it’s time to round out your character by defining his background. Being technologically advanced or culturally cosmopolitan is an advantage. Inadequacy in either area can be a crippling disadvantage.",
+			"calc": {
+				"points": 61
+			}
+		},
+		{
+			"id": "efabc345-f62d-4786-a4d5-2e4088a7ef91",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "2ba39e42-5eb0-44b1-b15e-6b4907b8eaa8",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "dad4d7e1-e1a1-43c7-89cc-ab51bcaad76b",
+							"type": "trait",
+							"name": "Congrencation",
+							"reference": "DW38",
+							"notes": "15-",
+							"userdesc": "You have a group of faithful followers – perhaps even worshippers – who will do whatever you ask of them, within reason. They won’t give you lots of money, but they will do odd jobs for you, and if you’re a deity, they believe in you, which is important. However, if you abuse them or fail to help them when they make reasonable requests, they’ll drift away from you. If they get killed, it’s up to you to recruit replacements – and most candidates will have heard what happened to the first lot.\n\nFor 10 points, you get a Congregation of up to 20 people; for 12 points, you get up to 50; and for 15 points, you get up to 100. Bigger Congregations than this are out of PC territory. A Congregation always has a frequency of appearance (above) of 15 or less; this is already factored into the point cost. On a roll of 16 or higher, they all have taxes to pay, there’s a secular festival, they’re all stuck in traffic, or whatever.\n\nNo one in your Congregation can be worth more than 10% ofyour own point value, so they’re quite fragile and thus best used as a source of noncombat aid and, if you need it, worship. Still, they’ll defend themselves if attacked (unless you’re the sort of priest or god who attracts fanatical pacifists). The GM should design Congregation members as characters, subject to this point limit (though you can offer suggestions regarding their abilities and histories); most will be broadly similar and interchangeable, although they may have a range of job skills. None can have Congregations of their own!",
+							"modifiers": [
+								{
+									"id": "4cf61ea2-796a-4bb6-8daa-94b76b4d65ab",
+									"type": "modifier",
+									"name": "Up to 20",
+									"cost": 10,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "b44d6527-ff81-488d-b369-34b04d30f471",
+									"type": "modifier",
+									"name": "Up to 50",
+									"cost": 12,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "49424630-bef1-46ba-ac1a-ad98e47ddc71",
+									"type": "modifier",
+									"name": "Up to 100",
+									"cost": 15,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "e2e95f0a-8f6d-44e2-929f-787676d74e2e",
+							"type": "trait",
+							"name": "Contact (@Who@)",
+							"reference": "DW38",
+							"userdesc": "A “Contact” is someone – from a beggar in the right gutter to a head of state – who’s willing to lend you his ability with a noncombat skill, either by providing you with useful information or by doing you small favours (pick any two of “quick,” “nonhazardous,” and “inexpensive”). The Contact’s point value is based on the skill he supplies, the frequency with which he helps you, and his reliability",
+							"modifiers": [
+								{
+									"id": "16508039-b9c3-4973-8151-b3a60078fba0",
+									"type": "modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "815c9373-73e7-4edc-8a82-a72820d3851f",
+											"type": "modifier",
+											"name": "Appears almost all the time",
+											"notes": "15-",
+											"cost": 3,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "05183ed1-b4d0-4f10-a14f-a1b164a8992e",
+											"type": "modifier",
+											"name": "Appears quite often",
+											"notes": "12-",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "2687a0a0-cf05-4650-a350-7790c38999e3",
+											"type": "modifier",
+											"name": "Appears fairly often",
+											"notes": "9-",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "44ffa02d-134b-4d0a-a47e-8d9edef75dc8",
+											"type": "modifier",
+											"name": "Appears quite rarely",
+											"notes": "6-",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Frequency of Appearance",
+									"reference": "DW38"
+								},
+								{
+									"id": "91ba18b5-96a1-45ce-b52e-014669b5c345",
+									"type": "modifier_container",
+									"children": [
+										{
+											"id": "8b0fefc6-5071-44c5-89ca-f8453e588828",
+											"type": "modifier",
+											"name": "Effective skill (12)",
+											"cost": 1,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "833fb095-f6c4-459c-8660-474161fdd329",
+											"type": "modifier",
+											"name": "Effective skill (15)",
+											"cost": 2,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "9e2567e7-25d8-4843-aab9-bd953050e948",
+											"type": "modifier",
+											"name": "Effective skill (18)",
+											"cost": 3,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "63b4314d-f722-442c-a1d8-c53b4c5733a5",
+											"type": "modifier",
+											"name": "Effective skill (21)",
+											"cost": 4,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "083ee360-33df-4ab1-8bf5-520f9e31f2e7",
+											"type": "modifier",
+											"name": "Can obtain information using supernatural talents",
+											"cost": 1,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"name": "Effective skill",
+									"reference": "DW38"
+								},
+								{
+									"id": "4f1df58c-e627-4551-8891-a62a05bb7515",
+									"type": "modifier_container",
+									"children": [
+										{
+											"id": "ed43bb5c-a588-42cb-a135-c515dafb5d60",
+											"type": "modifier",
+											"name": "Completely reliable",
+											"cost": 3,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "db8d124a-a83b-4d66-85ed-f70ce7eadcf8",
+											"type": "modifier",
+											"name": "Usually reliable",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "51804516-d8da-4c44-9585-2c6cd33482c3",
+											"type": "modifier",
+											"name": "Somewhat reliable",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Reliability",
+									"reference": "DW39"
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "71ac2c08-985e-4ee0-ab69-a57a8d39f99c",
+							"type": "trait",
+							"name": "Dependent (@Who@)",
+							"reference": "DW39",
+							"userdesc": "A “Dependent” is an NPC for whom you are or feel responsible; e.g., your child, kid brother, spouse, or even “boyfriend/girlfriend of the week.” You must take care of Dependents, and your foes can strike at you through them. If your Dependent is kidnapped or otherwise in danger, you must go to the rescue immediately, or the GM will deny you bonus character points (p. 219) for “acting out of character.” Furthermore, you never earn bonus character points for a game session in which your Dependent is killed or badly hurt.\n\nThree factors determine a Dependent’s disadvantage value: competence, importance (to you!), and frequency of appearance. Regardless of these details, you cannot earn points for more than two Dependents.",
+							"modifiers": [
+								{
+									"id": "6dabe749-ad49-41c7-91fe-c2b3c966bd6f",
+									"type": "modifier_container",
+									"children": [
+										{
+											"id": "26ab3118-378c-4c31-9b4b-8a9a525faab7",
+											"type": "modifier",
+											"name": "100% of your starting points",
+											"reference": "DW39",
+											"cost": -1,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "1a68ec2f-8c3f-4e3e-bd98-2499614a1431",
+											"type": "modifier",
+											"name": "75% of your starting points",
+											"reference": "DW39",
+											"cost": -2,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "c0ce555f-bb53-403a-85eb-70a498853fd0",
+											"type": "modifier",
+											"name": "50% of your starting points",
+											"reference": "DW39",
+											"cost": -5,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "9be77b60-79ba-4837-af58-4977dfaf3198",
+											"type": "modifier",
+											"name": "25% of your starting points",
+											"reference": "DW39",
+											"cost": -10,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "58fe8f1f-162c-49a3-b7a3-20f203cb53b4",
+											"type": "modifier",
+											"name": "0 or fewer points",
+											"reference": "DW39",
+											"cost": -15,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"name": "Competence",
+									"reference": "DW39"
+								},
+								{
+									"id": "7c421cfd-adcc-4704-86f5-58b2a8055abb",
+									"type": "modifier_container",
+									"children": [
+										{
+											"id": "9b3a8cbf-a2af-4a29-ab6f-c10dc19e7001",
+											"type": "modifier",
+											"name": "Employer or Acquaintance",
+											"reference": "DW40",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "738ac024-b159-4dea-9724-f23f833f5b6e",
+											"type": "modifier",
+											"name": "Friend",
+											"reference": "DW40",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "7768eb5d-8010-4f30-9435-398d20591c25",
+											"type": "modifier",
+											"name": "Loved one",
+											"reference": "DW40",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Importance",
+									"reference": "DW40"
+								},
+								{
+									"id": "6d2b32a7-0c63-4ecc-b621-7299d1f44a99",
+									"type": "modifier_container",
+									"children": [
+										{
+											"id": "a9fef622-0250-438a-afbc-a058220bfde0",
+											"type": "modifier",
+											"name": "Appears almost all the time",
+											"notes": "15-",
+											"cost": 3,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "329d662c-0d12-49e2-b768-fc5cb13c531d",
+											"type": "modifier",
+											"name": "Appears quite often",
+											"notes": "12-",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "903d1552-a676-441c-942e-97d77678fa82",
+											"type": "modifier",
+											"name": "Appears fairly often",
+											"notes": "9-",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "df7f0023-d667-4e85-afa4-a41d3ee802cc",
+											"type": "modifier",
+											"name": "Appears quite rarely",
+											"notes": "6-",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Frequency of Appearance",
+									"reference": "DW38"
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "e30ca52d-0cf0-4175-ae84-84b8bdcca23f",
+							"type": "trait",
+							"name": "Enemy (@Who@)",
+							"reference": "DW40",
+							"userdesc": "Some NPC, group, or organisation is actively working against you, personally. Three factors determine the disadvantage value of this “Enemy”: power, intent, and frequency of appearance. Regardless of such things, you may not take more than two distinct Enemy disadvantages, or claim more than -60 points from Enemies. (Going right up to these limits is your choice, but might well mean being jailed or killed before long!)",
+							"modifiers": [
+								{
+									"id": "c2eabd03-c0b3-4a89-ad55-e910fae30ebb",
+									"type": "modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "de332956-d4a1-4af6-9339-34f1fa617363",
+											"type": "modifier",
+											"name": "Weak Individual",
+											"notes": "50% of your starting points",
+											"cost": -5,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "73913cf5-78dc-4fa9-93e8-9182656fb07e",
+											"type": "modifier",
+											"name": "Equal Individual",
+											"notes": "100% of your starting points",
+											"cost": -10,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "81b5a233-41ef-48a3-8d98-450dab7c74a2",
+											"type": "modifier",
+											"name": "Powerful Individual",
+											"notes": "\u003e150% of your starting points",
+											"cost": -20,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "4ad57666-9f27-4986-9191-16d65214969b",
+											"type": "modifier",
+											"name": "Weak Group",
+											"cost": -10,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "8427a345-55ea-4e91-a797-cef5991899d4",
+											"type": "modifier",
+											"name": "Medium Group",
+											"cost": -20,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "08aa132f-60f2-4bed-b3a3-ef4321d2f09f",
+											"type": "modifier",
+											"name": "Large/Powerful Group",
+											"cost": -30,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "19ea1f4b-fc64-4c1d-8217-1c7f5cd09190",
+											"type": "modifier",
+											"name": "Utterly Formidable Group",
+											"cost": -40,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"name": "Power",
+									"reference": "DW40"
+								},
+								{
+									"id": "aa5c3eb5-f4b6-4b9b-927b-653e6b870517",
+									"type": "modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "43075921-7dd0-468f-9609-296e9f7ebf0b",
+											"type": "modifier",
+											"name": "Watcher",
+											"cost": 0.25,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "85d6d113-01ac-4074-a7ce-21572db84555",
+											"type": "modifier",
+											"name": "Rival",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "1b7c0201-7ba5-46e9-9c3d-2398527a3712",
+											"type": "modifier",
+											"name": "Hunter",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Intent",
+									"reference": "DW40"
+								},
+								{
+									"id": "6abde3a4-f8aa-48b4-937d-c450bfe95038",
+									"type": "modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "a6c00191-87e2-4211-94de-1f7075d9954f",
+											"type": "modifier",
+											"name": "Appears almost all the time",
+											"notes": "15-",
+											"cost": 3,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "8a0d80fa-3c13-48dd-a4ae-cbcc236bce6a",
+											"type": "modifier",
+											"name": "Appears quite often",
+											"notes": "12-",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "df4a17ee-c948-45f0-a2ff-5840d6e6e750",
+											"type": "modifier",
+											"name": "Appears fairly often",
+											"notes": "9-",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "223b5066-9353-42b0-a67c-2584bfe76c40",
+											"type": "modifier",
+											"name": "Appears quite rarely",
+											"notes": "6-",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Frequency of Appearance",
+									"reference": "DW38"
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "3f7a6864-a4d3-4af7-8204-3e9b65e94173",
+							"type": "trait",
+							"name": "Patron",
+							"reference": "DW41",
+							"userdesc": "You have a more-powerful individual or organisation looking out for you personally; e.g., a wealthy relative, or a politician who sees you as his chosen successor. An ordinary employer isn’t such a “Patron,” but a commanding officer who will go out of his way to help you might be. If a leader is looking after you and can command the resources of a city, nation, or organisation, you may treat that whole body as your Patron, although the motivation happens to come from the individual at the top.\n\nThe Patron’s base point cost depends on its power. Use the following categories as a guide, but be aware that some Patrons won’t fit neatly into any of them:",
+							"modifiers": [
+								{
+									"id": "2327b4e2-4b1c-4941-afbe-ce4775f1e03b",
+									"type": "modifier_container",
+									"children": [
+										{
+											"id": "a99a5858-0f56-4ed0-a102-552eaa6e7222",
+											"type": "modifier",
+											"name": "@Who: Individual with 150% of PC's starting points@",
+											"cost": 10,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "3977cc18-2515-4793-b8ed-43a82995ad06",
+											"type": "modifier",
+											"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
+											"cost": 10,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "fa59fc21-5707-4d97-8097-03b209d46258",
+											"type": "modifier",
+											"name": "@Who: Individual with twice the PC's starting points@",
+											"cost": 15,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "631b147d-c585-4679-a67b-dbe8a8838cbb",
+											"type": "modifier",
+											"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
+											"cost": 15,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "75a7a34b-aed4-4108-aa6e-cf969a596f58",
+											"type": "modifier",
+											"name": "@Who: An ultra-powerful individual@",
+											"cost": 20,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "4b13c656-a481-4cad-95ef-8c63c8865d50",
+											"type": "modifier",
+											"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
+											"cost": 20,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "2e82bc75-004f-411b-a855-b704cfb309a8",
+											"type": "modifier",
+											"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
+											"cost": 25,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "3c15a25d-0b50-410d-8705-11564f7a24aa",
+											"type": "modifier",
+											"name": "@Who: A national government or giant multi-national organization@",
+											"cost": 30,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"name": "Power",
+									"reference": "DW41"
+								},
+								{
+									"id": "5be71058-f3dc-431f-aa1b-f451e2467eb1",
+									"type": "modifier_container",
+									"children": [
+										{
+											"id": "bc956e90-217e-4f9a-beb6-b055c52e48fc",
+											"type": "modifier",
+											"name": "Appears almost all the time",
+											"notes": "15-",
+											"cost": 3,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "21ed66d7-0e12-4ed2-8dc1-8e078443fd82",
+											"type": "modifier",
+											"name": "Appears quite often",
+											"notes": "12-",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "d5a208f6-3f9a-4673-a6c5-03db87808cf2",
+											"type": "modifier",
+											"name": "Appears fairly often",
+											"notes": "9-",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "77a00b65-1e20-4324-97cb-55b786e70253",
+											"type": "modifier",
+											"name": "Appears quite rarely",
+											"notes": "6-",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Frequency of Appearance",
+									"reference": "DW38"
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"name": "Friends and Foes",
+					"userdesc": "Some specific NPCs may be inclined to help you in various ways. You might be obliged to take care of others. And yet others may want to harm you.",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "b767e4dd-30bc-4db1-a7e0-7c407b571ba6",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "51ee4c96-264c-47da-9d88-e9e17f5c0dc1",
+							"type": "trait_container",
+							"children": [
+								{
+									"id": "e22c51ef-1472-47fc-9730-8de7746d371e",
+									"type": "trait",
+									"name": "Social Stigma (Logical Impossibility)",
+									"reference": "DW36",
+									"userdesc": "Even on the Disc, certain things are generally considered impossible, and some of them turning out to be real doesn’t change people’s minds. You are an example. This doesn’t give you a reaction penalty, because people refuse to react to you at all if they can help it! If you force them to acknowledge your existence – e.g., by getting in their faces and shouting – they’ll either be grudging and angry, pretend that they were talking to you all along but you didn’t say much of interest, or spend many boring hours saying “Gosh.” If you try to exploit your invisibility by, say, stealing stuff, they’ll treat you as an inanimate object or a mindless animal, subject to casual violence.",
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "bf8ec37c-276d-4147-9816-cbb9f262019c",
+									"type": "trait",
+									"name": "Social Stigma (Minor)",
+									"reference": "DW36",
+									"notes": "You are underage by your culture’s standards. You must buy off this trait when you reach “legal age” (usually 18) for your time and place.",
+									"userdesc": "You are under-age. You suffer -2 on reaction rolls whenever you try to deal with others as an adult; they might like you, but they don’t respect you. You may be barred from drinking dens, war parties, guild membership, etc. You must buy this off when you reach “legal age.”",
+									"base_points": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others whenever you try to deal with them as an adult; they might like you, but they do not fully respect you",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "eaf67949-ff7e-450a-a152-a2cb02520730",
+									"type": "trait",
+									"name": "Social Stigma (Minority Group)",
+									"reference": "DW36",
+									"notes": "You are a member of a minority that the dominant culture around you regards as “barbarians” or “inferior.”",
+									"userdesc": "You belong to a minority that people around you regard as “barbarians” or “inferior.” You get -2 on reaction rolls made by anyone except your own kind. In an area, profession, or situation where your minority is especially rare, you get +2 on reaction rolls made by your own kind. This disadvantage also fits undead and lycanthropes in many parts of the Disc; however wellbehaved they are, people don’t quite trust them.",
+									"base_points": -10,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others except your own kind",
+											"amount": -2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others of your own kind in an area, profession, or situation where your minority is especially rare",
+											"amount": 2
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "710747d3-8b42-41df-8e9f-3e290b6cbb8f",
+									"type": "trait",
+									"name": "Social Stigma (Monster)",
+									"reference": "DW36",
+									"userdesc": "You’re a monstrosity or other being that’s hated or feared, regardless of actual appearance or disposition. This gives you -3 on all reaction rolls, and you’re liable to be hunted on sight. However, you get +3 to Intimidation rolls in situations where you have the upper hand (GM’s opinion)",
+									"base_points": -15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "intimidation"
+											},
+											"amount": 1
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -3
+										}
+									],
+									"calc": {
+										"points": -15
+									}
+								},
+								{
+									"id": "03ed7824-f453-4a8c-9c0b-70afb501d6fe",
+									"type": "trait",
+									"name": "Social Stigma (Overdressed Foreigner)",
+									"reference": "DW36",
+									"userdesc": "Because of the way that you talk, act, or dress, people in most places regard you as “not one of us,” and probably as flashy and annoyingly rich. This usually only nets you a -1 reaction penalty (though not from others who share your background, or from self-consciously cosmopolitan individuals), and many people will suppress their hostility – but only because they want your money. You’re a magnet for con artists, pickpockets, overcharging merchants, would-be guides, and other rogues, some blatant and annoying, some subtle and skilled. Should you be taken for a wizard, you suffer -3 reactions from Unseen University graduates (who look upon you with suspicion) and would-be barbarian heroes (who consider you a possible target), although you may also attract a few interested followers.",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others that don't share your background or -3 if you are mistaken for a wizard",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": 0
+									}
+								},
+								{
+									"id": "7f50be5c-e04b-4778-b153-bfb0f5a3110b",
+									"type": "trait",
+									"name": "Social Stigma (Second-Class Citizen)",
+									"reference": "DW36",
+									"notes": "You belong to a group that receives fewer rights and privileges than “full citizens.”",
+									"userdesc": "You belong to a sex, species, etc., that receives fewer rights and privileges than “full citizens.” This gives -1 on all reaction rolls except from others of your own kind.",
+									"base_points": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others except those of your own kind",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "ebef8294-9b4f-462f-8391-77c54125f106",
+									"type": "trait",
+									"name": "Social Stigma (Uneducated)",
+									"reference": "DW36",
+									"userdesc": "You’re thought to be wilfully ignorant and a bit stupid, probably because you lack much education. People with even a minimal “normal” education react to you at -1 and treat you as a bit of an idiot",
+									"base_points": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "3e545c4e-824b-4039-94f1-4481c941905a",
+									"type": "trait",
+									"name": "Social Stigma (Valuable Property)",
+									"reference": "DW36",
+									"userdesc": "Society regards you as somebody’s property rather than as a legal person. This takes the form of limited freedom or lack of intellectual respect, rather than a reaction modifier. Enslaving sapient beings is illegal on most of the Disc these days, but it was fairly widespread in the past, and not all sapient beings are recognised as such",
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"name": "Social Stigma",
+							"userdesc": "You belong to a group or a category that your society deems inferior, and this is obvious from your physical appearance, dress, manner, or speech; or easily learned by anyone who cares to check up on you; or the result of public denouncement (e.g., by a chieftain or a priest). This trait is the opposite of Social Regard (p. 36), and it gives you a reaction penalty and/or restricts your social mobility. It’s unrelated to Status (pp. 37-38) – you can hold a high position in society and still be stigmatised. Some Stigmas can be combined; e.g., a member of an enslaved minority might have both Minority Group and Valuable Property.",
+							"calc": {
+								"points": -60
+							}
+						},
+						{
+							"id": "f18f54e5-d890-4d43-8596-4abeae022809",
+							"type": "trait_container",
+							"children": [
+								{
+									"id": "449f48da-4f20-42ab-ac6d-17ece2f9d3f1",
+									"type": "trait",
+									"name": "High Status",
+									"reference": "DW37",
+									"notes": "@Description@",
+									"levels": 1,
+									"points_per_level": 5,
+									"can_level": true,
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "3c2d508f-6cc1-4c32-be5c-f0336ecc7ef1",
+									"type": "trait",
+									"name": "Low Status ",
+									"reference": "DW37",
+									"notes": "@Description@",
+									"levels": 1,
+									"points_per_level": -5,
+									"can_level": true,
+									"calc": {
+										"points": -5
+									}
+								}
+							],
+							"name": "Status",
+							"userdesc": "Status is the primary measure of social standing. Levels range from -2 to 8, with an ordinary citizen being Status 0. If you don’t\nspecifically buy Status, you have Status 0. Status costs 5 points per level; e.g., Status 5 costs 25 points, while Status -2 is -10 points. High Status costs money to support, so you’ll probably need high Wealth (pp. 33-34) to go with it.\n\nStatus greater than 0 means you’re a member of the dominant classes. Consequently, others in your culture only defer to you, giving you a bonus on all reaction rolls equal to the difference between your Status and theirs; e.g., a Status 2 merchant reacts to a Status 5 duke at +3. However, criminals and street rabble may hate the upper classes, and react to them at large penalties if they can get away with it (GM’s option). Some figures, such as witches and Hubland monks, see themselves as standing outside normal hierarchies, so Status is unlikely to influence their reactions either way. A high-Status character will normally treat somebody of lower but non-negative Status with distant politeness (no reaction modifier), but gaffes can quickly turn differences into penalties for the lower-Status person; e.g., if that merchant did something actively annoying to the duke, the duke would remember the difference between them and react at -3.\n\nHowever, Status less than 0 means you’re definitely of the lower orders. Higher-Status characters will often react to you at a penalty equal to the difference in level, although they’ll tolerate your existence so long as you seem to know your place. Alternatively, they may carefully ignore you.\n\nAll of which said, Discworlders are often a remarkably democratic lot, considering that most of them are traditionalist monarchists. Much of the time, they only really acknowledge four social categories: Proper Gentlefolk (to whom other people are polite out of tradition or fear), Nouveau Riche (about whom people are often quite rude in private, but who have the power to purchase at least a working facsimile of respect), the Supernatural Lot (wizards, witches, and priests, who are a bit weird but who might be able to turn you into a frog, so be careful), and Everyone Else (common folk). For dealings within a single category, the GM can safely ignore fine gradations of Status except when portraying nitpicking snobs or inverted snobs.\n\nThe Status Table shows what each Status level typically signifies. “Monthly Cost” is the cost of living at that Status level; it keeps you alive and looking the part. If you can’t raise the money to match your Status each month, then you must live in a style that you can afford – and so you’ll be treated as having lower Status than you’ve paid the points for. (If you can’t make Status -2 expenses, you’re literally starving to death on the street.) If you live below your nominal Status for more than a couple of months, you’ll probably have to do something impressive to restore your credibility later (give a good party, say, or acquire a big house). If your Status comes partly or entirely from Rank (see Special Cases for Status, p. 38), then the salary attached to that Rank will generally be enough to support it – but your lifestyle may be somewhat circumscribed by the job. See Living Expenses (pp. 148-149) and Characters With Jobs (p. 173) for more on all this.",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "c01505d6-44de-48ad-bd51-fe85b100741a",
+							"type": "trait",
+							"name": "@Type@ Rank",
+							"reference": "DW35",
+							"userdesc": "Rank represents position in some structured organisation that gives higher-ranked members significant authority over lowerranked ones. The lowest Rank in a structure is always 0, which is free and grants no particular benefits. The highest depends on the organisation’s size and nature, but never exceeds 8.\n\nThe classic example is Military Rank, ranging from 0 (Private, Footman, etc.) to 8 (Supreme Commander of an empire’s army or navy). The Ankh-Morpork City Watch has Watch Rank (p. 256), and other cities are doubtless imitating that structure as they imitate Ankh-Morpork generally. Formal, powerful religions have hierarchies with Religious Rank (p. 302). The governing bureaucracy of the Agatean Empire has Administrative Rank; other Discworld bureaucracies aren’t sufficiently structured and disciplined to count as having a Rank structure – although in Ankh-Morpork, the Patrician’s palace and the Post Office may both come close.\n\nIf you have high Rank, you can order those of lower Rank to assist you – but only for purposes related to the organisation. Individuals with higher Rank can likewise command you, so Rank often comes with a Duty (pp. 59-60).",
+							"points_per_level": 5,
+							"can_level": true,
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "fd8e7cb3-fd42-4f7b-bdd6-65041366b4ad",
+							"type": "trait",
+							"name": "Clerical Investment",
+							"reference": "DW34",
+							"userdesc": "You’re a priest of a recognised religion. This gives +1 to reactions from those who share your religion or otherwise respect your faith – that is, most sensible people, as gods and their temples can be touchy, although wizards and witches make a point of not being impressed. You may also buy Religious Rank (p. 35) if your church or temple uses it.\n\nTechnically, this is a purely social advantage, granting no particular spiritual insight or powers. However, your god will (probably!) recognise your status and feel obliged to listen to your prayers. He may actually respond, if anything seems important enough to him – although if interesting events are taking place elsewhere, or something amusing is happening on Cori Celesti, you’re out of luck. You might even be permitted to take him as a Patron (p. 41), which is allowed to very few nonclerics. (You can only get personal aid if your deity is your Patron; otherwise, there’s no point in bothering him about such matters.) Lastly, divine protocol means that you’re generally immune to being zapped by other gods, unless you do something really stupid.\n\nClerics may also be required to take a Duty (pp. 59-60), although that will usually be Nonhazardous.",
+							"base_points": 5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from members of your religion and those who respect your faith",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "7bf476a3-70e2-4c49-be5f-c4f9de892af1",
+							"type": "trait",
+							"name": "Legal Enforcement Powers",
+							"reference": "DW35",
+							"notes": "@Description@",
+							"userdesc": "You’re an agent of the law. For 5 points, you have local jurisdiction, and you can arrest and search people (e.g., a constable in a well-run town). For 10 points, you have national jurisdiction, or may disregard some significant legal limits, or can even kill with relative impunity (e.g., many royal guardsmen). For 15 points, you enjoy broad privileges and discretion (e.g., some ruler’s personal agent). You probably also possess a Duty (pp. 59-60) and Rank (below).\n\nPowers broad enough to be worth 15 points are rare on the Disc, though not unknown. Special agents may be granted special powers – but rulers with the authority to set that up also tend to arrange matters so that the agent is left to dangle in the wind if the mission goes wrong. You need to be exceptionally well regarded by a powerful ruler to qualify",
+							"modifiers": [
+								{
+									"id": "e86a6581-3f95-42f8-ab13-7fa508087391",
+									"type": "modifier",
+									"name": "Local",
+									"cost": 5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "99762624-7c37-4e83-8562-e9d9ca102e7e",
+									"type": "modifier",
+									"name": "National",
+									"cost": 10,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "95893915-8695-4a82-b935-9d5142c13aae",
+									"type": "modifier",
+									"name": "Multinational",
+									"cost": 15,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "d5c4cec2-d0bc-4bb5-bf6a-0728d99f4c9d",
+							"type": "trait",
+							"name": "Legal Immunity",
+							"reference": "DW35",
+							"userdesc": "You’re exempt from some or all laws. Should you break them, ordinary law enforcers don’t have the power to charge you. Only one authority – e.g., your temple, a guild court, or the king – can judge or punish you. If the rules that govern your behaviour are merely different from ordinary law, but just as strict, this costs 5 points. If they’re less strict, it’s 10 points. And if you can do nearly anything you please provided that you don’t injure your group’s long-term interests, pay 15 points\n\nLegal Immunity is usually accompanied by high Status (pp. 37-38), Clerical Investment (p. 34), and/or a Duty (pp. 59-60). Wizards at Unseen University don’t have this advantage, although they theoretically claim a degree of immunity to civil law, because civil law is patchily and informally enforced in Ankh-Morpork anyway, and a wizard who breaks the rules can expect much the same consequences as anyone else. Members of the Assassins’ and Thieves’ Guilds do have the 5-point version, however, because while the Watch will try to stop assassinations and a lot of non-contractual thievery, the chance of a Guild member being tracked down and brought to justice is pretty low. On the other hand, both are subject to their respective guilds’ rules.\n\nA special version of this is available to Igors (pp. 140-141):",
+							"modifiers": [
+								{
+									"id": "f677ccb3-f16d-4c99-bae8-340a1c6b6a93",
+									"type": "modifier",
+									"name": "Strict Group",
+									"reference": "DW35",
+									"cost": 5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "18ed8fc9-74f8-49b7-a71e-9543a4dd3123",
+									"type": "modifier",
+									"name": "Less Strict Group",
+									"reference": "DW35",
+									"cost": 10,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "fa4dd52f-db79-4c05-810a-b37c4134623e",
+									"type": "modifier",
+									"name": "Can do nearly anything",
+									"reference": "DW35",
+									"cost": 15,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "e571cbad-f8c8-45cc-96da-b388de14b537",
+									"type": "modifier",
+									"name": "Igor Immunity",
+									"reference": "DW35",
+									"notes": "In Uberwald and some adjacent areas, an Igor can take no particular blame for his employer’s actions.",
+									"cost": 5,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "25d7cd0d-f21e-40f8-8f66-1693fc1dedb6",
+							"type": "trait",
+							"name": "Social Regard",
+							"reference": "DW35",
+							"notes": "@Type: Feared, Respected or Venerated@: @Reason@",
+							"userdesc": "You belong to a class, race, or group that your society respects. Every 5 points in Social Regard gives you +1 to reaction rolls (maximum +4). This isn’t a Reputation, despite the similarities – you’re treated well because of what you are, not because of who you are. Exactly how you’re treated on a good reaction roll will depend on the type of Regard:\n\nFeared: Others react as if you had successfully used Intimidation (p. 74). People stand aside or run away.\n\nRespected: You receive polite deference. Noncombat interactions usually go smoothly for you – but sometimes, the kowtowing gets in the way.\n\nVenerated: Total strangers react to you in a caring way, give up their seats, and receive your every word as pearls of wisdom. They also try to prevent you from putting yourself in danger.\n\nWitches may be either Feared or Respected, depending on their personal style – how much they emphasise the dangerous, cackling old hag or the useful wise-woman thing – but trainee witches don’t enjoy either until they’ve acquired a bit of credibility.",
+							"levels": 1,
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those who hold you in high regard for being a @Reason@, in a @Type: Feared, Respected or Venerated@ way.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 5
+							}
+						}
+					],
+					"name": "Importance",
+					"userdesc": "Your formally recognised place in society is distinct from your personal fame and fortune.",
+					"calc": {
+						"points": -50
+					}
+				},
+				{
+					"id": "4110f037-0e85-4be6-884f-9d29fd28d49f",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "b1e6660e-86a2-42b4-b480-dbc9365ea8e0",
+							"type": "trait",
+							"name": "Bad Reputation",
+							"reference": "DW34",
+							"modifiers": [
+								{
+									"id": "1204b0d1-3605-4635-bb82-1912459df355",
+									"type": "modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "38aa3113-4709-485c-be35-ba35d96192fd",
+											"type": "modifier",
+											"name": "Almost everyone",
+											"reference": "DW34",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "39082380-367d-4319-9daf-854976f45562",
+											"type": "modifier",
+											"name": "Almost everyone except @large class of people@",
+											"reference": "DW34",
+											"cost": 0.67,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "b43f0211-b5bf-4271-b6cc-acd6483af8d2",
+											"type": "modifier",
+											"name": "@Large class of people@",
+											"reference": "DW34",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "ca59a34a-2467-417f-9764-46e7617201a2",
+											"type": "modifier",
+											"name": "@Small class of people@",
+											"reference": "DW34",
+											"cost": 0.33,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "People Affected"
+								},
+								{
+									"id": "b16f7537-1705-4e89-988a-c48b1bc2fef4",
+									"type": "modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "bf87af2b-67fd-43ca-b53d-22911e628cfe",
+											"type": "modifier",
+											"name": "Recognized all the time",
+											"reference": "DW34",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "a0d8d318-d895-4cd6-9412-3b4839438dbe",
+											"type": "modifier",
+											"name": "Recognized sometimes",
+											"reference": "DW34",
+											"notes": "10-",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "c32da9c0-87ba-4504-b87d-7ae275bec1ce",
+											"type": "modifier",
+											"name": "Recognized occasionally",
+											"reference": "DW34",
+											"notes": "7-",
+											"cost": 0.33,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Frequency of Recongnition"
+								}
+							],
+							"levels": 1,
+							"points_per_level": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others aware of your reputation",
+									"amount": -1,
+									"per_level": true
+								}
+							],
+							"round_down": true,
+							"can_level": true,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "1c6d3433-d615-4326-861a-927c529d991a",
+							"type": "trait",
+							"name": "Good Reputation",
+							"reference": "DW34",
+							"modifiers": [
+								{
+									"id": "1204b0d1-3605-4635-bb82-1912459df355",
+									"type": "modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "38aa3113-4709-485c-be35-ba35d96192fd",
+											"type": "modifier",
+											"name": "Almost everyone",
+											"reference": "DW34",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "39082380-367d-4319-9daf-854976f45562",
+											"type": "modifier",
+											"name": "Almost everyone except @large class of people@",
+											"reference": "DW34",
+											"cost": 0.67,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "b43f0211-b5bf-4271-b6cc-acd6483af8d2",
+											"type": "modifier",
+											"name": "@Large class of people@",
+											"reference": "DW34",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "ca59a34a-2467-417f-9764-46e7617201a2",
+											"type": "modifier",
+											"name": "@Small class of people@",
+											"reference": "DW34",
+											"cost": 0.33,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "People Affected"
+								},
+								{
+									"id": "b16f7537-1705-4e89-988a-c48b1bc2fef4",
+									"type": "modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "bf87af2b-67fd-43ca-b53d-22911e628cfe",
+											"type": "modifier",
+											"name": "Recognized all the time",
+											"reference": "DW34",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "a0d8d318-d895-4cd6-9412-3b4839438dbe",
+											"type": "modifier",
+											"name": "Recognized sometimes",
+											"reference": "DW34",
+											"notes": "10-",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "c32da9c0-87ba-4504-b87d-7ae275bec1ce",
+											"type": "modifier",
+											"name": "Recognized occasionally",
+											"reference": "DW34",
+											"notes": "7-",
+											"cost": 0.33,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"name": "Frequency of Recongnition"
+								}
+							],
+							"levels": 1,
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others aware of your reputation",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"round_down": true,
+							"can_level": true,
+							"calc": {
+								"points": 5
+							}
+						}
+					],
+					"name": "Reputaion",
+					"userdesc": "Reputation can be an advantage or a disadvantage, depending on what people think of you. You can be known for bravery, ferocity, eating green snakes, or whatever you want. However, you must give specifics.\n\nSpecify the reaction-roll modifier that you get from people who recognise you. This determines your reputation’s base cost. For every +1 bonus to reactions (up to +4), the cost is 5 points. For every -1 penalty (down to -4), the cost is -5 points. This cost may then be modified further",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "2ea35305-a4c1-4bb0-b601-3fa0c5e108fb",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "75982afa-c269-440f-b835-93e7ee36bb0d",
+							"type": "trait",
+							"name": "Average",
+							"reference": "DW33",
+							"notes": "Starting wealth is normal",
+							"userdesc": "Wealth Multiplier 1. The default wealth level, which usually accompanies the default Status level: Status 0",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "f92eb6fd-6018-49fa-acbc-edffdb298357",
+							"type": "trait",
+							"name": "Comfortable Wealth",
+							"reference": "DW33",
+							"notes": "Starting wealth is twice normal",
+							"userdesc": "Wealth Multiplier 2. You likely work for a living, but your lifestyle is better than most. You probably make enough to support Status 1.",
+							"base_points": 10,
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "dac96f3d-db4e-4edd-9249-f00ca6f1db3c",
+							"type": "trait",
+							"name": "Dead Broke",
+							"reference": "DW33",
+							"notes": "Starting wealth is 0",
+							"userdesc": "You have no job, no source of income, no money, and no property other than the clothes you’re wearing. Either you’re unable to work or there are no jobs to be found. You’re almost certainly Status -2.",
+							"base_points": -25,
+							"calc": {
+								"points": -25
+							}
+						},
+						{
+							"id": "4a77edc3-6101-406a-b9f6-e0ecd70a1094",
+							"type": "trait",
+							"name": "Filthy Rich",
+							"reference": "DW33",
+							"notes": "Starting wealth is 100x normal",
+							"userdesc": "Wealth Multiplier 100! You can buy almost anything you want without considering the cost. You probably rate high Status whatever your birth; money always talks, and yours shouts.",
+							"base_points": 50,
+							"calc": {
+								"points": 50
+							}
+						},
+						{
+							"id": "b4290738-3e54-4301-9562-f9407ab0e3e5",
+							"type": "trait",
+							"name": "Multimillionaire",
+							"reference": "DW33",
+							"notes": "Starting wealth is 100x10^level normal",
+							"userdesc": "This represents additional Wealth beyond Filthy Rich, and it must be purchased on top of that. For every 25 points you spend beyond the 50 points for Filthy Rich, increase Wealth Multiplier by another factor of 10: Multimillionaire 1 costs 75 points and gives Wealth Multiplier 1,000, Multimillionaire 2 costs 100 points and gives Wealth Multiplier 10,000, and so on.",
+							"base_points": 50,
+							"levels": 1,
+							"points_per_level": 25,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "filthy rich"
+										}
+									}
+								]
+							},
+							"can_level": true,
+							"calc": {
+								"points": 75
+							}
+						},
+						{
+							"id": "df1b6171-ce9e-4223-b4ee-cbc4749fb81d",
+							"type": "trait",
+							"name": "Poor",
+							"reference": "DW33",
+							"notes": "Starting wealth is 1/5 normal",
+							"userdesc": "Wealth Multiplier 1/5. Some jobs aren’t available to you, and no job you’ll ever find pays very well. You’re probably Status -2.",
+							"base_points": -15,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "5f602035-d56d-4734-b6a1-f55d36cb3ef5",
+							"type": "trait",
+							"name": "Struggling",
+							"reference": "DW33",
+							"notes": "Starting wealth is ½ normal",
+							"userdesc": "Wealth Multiplier 1/2. Almost any job is open to you (you can be a Struggling lawyer or opera soloist), but you don’t earn much. You’re most likely Status -1.",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "e692f16f-b168-4dc8-9b19-8050be15c6c5",
+							"type": "trait",
+							"name": "Very Wealthy",
+							"reference": "DW33",
+							"notes": "Starting wealth is 20x normal",
+							"userdesc": "Wealth Multiplier 20, potentially taking you to Status 3+, although in many places that needs aristocratic birth or at least political power",
+							"base_points": 30,
+							"calc": {
+								"points": 30
+							}
+						},
+						{
+							"id": "4cd7dc41-8e53-4bd0-a576-75e938d13158",
+							"type": "trait",
+							"name": "Wealthy",
+							"reference": "DW33",
+							"notes": "Starting wealth is 5x normal",
+							"userdesc": "Wealth Multiplier 5. You live very well indeed. You’re likely to be Status 2.",
+							"base_points": 20,
+							"calc": {
+								"points": 20
+							}
+						}
+					],
+					"name": "Wealth",
+					"userdesc": "Above-average Wealth is an advantage; below-average Wealth, a disadvantage. Each level of Wealth has a Wealth Multiplier attached to it; this applies to both your starting funds (below) and your income from regular jobs (p. 173), although not to any money that you pick up while adventuring. Each level also has a typical level of Status (pp. 37-38) associated with it, but this is not mandatory – plenty of people are poorer or richer than their position in society implies.\n\nThe GM may choose to set an upper limit on Wealth, especially if he wants the PCs to go on traditional sorts of adventures. Someone who has spent many points on Wealth can get a lot done by paying someone else to do it, but might not be very competent himself. Being Wealthy should be plenty in most games – and the player who wants more than Multimillionaire 3 will need to explain how his PC came to be richer than the richest man in Ankh-Morpork!",
+					"calc": {
+						"points": 135
+					}
+				}
+			],
+			"name": "Wealth and Influence",
+			"userdesc": "You need to determine your position in your society, too: How much money do you have, what privileges do you enjoy, and how do others react to you?",
+			"calc": {
+				"points": 85
+			}
+		},
+		{
+			"id": "b20513d6-3ed1-4f01-9d94-0cd8b33d35b8",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "adbc5c6f-3ba5-4a5b-ba1a-42bde1d56d88",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "27b14c8b-b005-48bf-843f-cd2afe03eaea",
+							"type": "trait",
+							"name": "Acute Hearing",
+							"reference": "DW41",
+							"levels": 1,
+							"points_per_level": 2,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "hearing",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 2
+							}
+						},
+						{
+							"id": "1dea212a-2e86-4e5d-b3ee-5d4f52a7bdd1",
+							"type": "trait",
+							"name": "Acute Taste \u0026 Smell",
+							"reference": "DW41",
+							"levels": 1,
+							"points_per_level": 2,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "taste_smell",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 2
+							}
+						},
+						{
+							"id": "a23aab07-01a1-4163-ae50-6fea44724009",
+							"type": "trait",
+							"name": "Acute Touch",
+							"reference": "DW41",
+							"levels": 1,
+							"points_per_level": 2,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "touch",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 2
+							}
+						},
+						{
+							"id": "f68ffcfe-97c2-4cd6-8fae-0ed0bacf8f28",
+							"type": "trait",
+							"name": "Acute Vision",
+							"reference": "DW41",
+							"levels": 1,
+							"points_per_level": 2,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "vision",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 2
+							}
+						}
+					],
+					"name": "Acute Senses",
+					"userdesc": "You have superior senses. Each Acute Sense is a separate advantage that gives +1 per level to all Sense rolls (pp. 169-170) you make – or the GM makes for you – using that one sense. Available types:",
+					"calc": {
+						"points": 8
+					}
+				},
+				{
+					"id": "dc0391dc-0062-404d-ae61-c891794f0b5d",
+					"type": "trait",
+					"name": "Ambidexterity",
+					"reference": "DW41",
+					"userdesc": "You can fight or otherwise work equally well with either hand and never suffer the -4 DX penalty for using the “off” hand (p. 29).",
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "728acd17-6e68-4eab-af4e-583d7456420f",
+					"type": "trait",
+					"name": "Channeling",
+					"reference": "DW41",
+					"userdesc": "You can allow spirits to speak through you. To do so, you must enter a trance, taking one minute of concentration and a Will roll (at +2 if you have Autotrance, p. 50). You’re unaware of the world around you while you’re in this state. After that, any spirit in the immediate vicinity can enter your body and use it to speak. The GM controls what the spirit says. The spirit will answer questions put to it by others, but it isn’t bound to tell the truth.\n\nThe spirit can use your body only to communicate. However, if it has the ability to possess and control living beings, it can attempt to possess you. It’s effectively touching you, but you’re considered “wary,” which is worth +5 to resist.",
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "5845cba7-b2fc-45d4-a21c-fc8291f3f89d",
+					"type": "trait",
+					"name": "Combat Reflexes",
+					"reference": "DW41",
+					"notes": "Never freeze",
+					"userdesc": "You have fast reactions and are rarely surprised for long. You get +1 to all active defence rolls (p. 180), +1 to Fast-Draw skill, and +2 to Fright Checks (pp. 170-171). You never “freeze” in a surprise situation, and you have +6 on all IQ rolls to wake up.\n\nThis advantage is mostly found among experienced warriors, but it’s also useful to devout cowards and criminals. Alchemists and wizards sometimes acquire it as a way to survive their own experiments: When the crucible starts to fizz, duck.",
+					"base_points": 15,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "42ed39aa-77b3-434d-89e0-385e9e096ba5",
+					"type": "trait",
+					"name": "Danger Sense",
+					"reference": "DW41",
+					"userdesc": "You can’t depend on it, but sometimes you get a feeling that something’s wrong. The GM rolls once against your Perception, secretly, in any situation involving an ambush, impending disaster, etc. On a success, you get enough warning that you can take action. A roll of 3 or 4 means you get a little detail as to the nature of the danger.",
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "98d9960e-6d8c-40ec-8191-8033b7b8e9d4",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "aa1b5cb7-7693-474e-955a-4780c523070f",
+							"type": "trait",
+							"name": "Animal Empathy",
+							"reference": "DW41",
+							"userdesc": "Works on animals, usually defined as nonsupernatural beings with IQ 5 or below. A few creatures with IQ 6+, such as the smartest sorts of Discworld dogs, also count as “animals.” In addition to reading animals’ moods, you can use Influence skills (pp. 74-75) on them just as you would on sapient beings.",
+							"base_points": 5,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "d47c2d28-3320-4b02-baf9-92c460333feb",
+							"type": "trait",
+							"name": "Empathy",
+							"reference": "DW41",
+							"userdesc": "Works on “ordinary” creatures of IQ 6+: humans, dwarfs, trolls, etc. In addition to mood-reading, it gives you +3 to Detect Lies and Fortune-Telling skills, and to Psychology rolls to analyse a subject you can converse with",
+							"base_points": 15,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "detect lies"
+									},
+									"amount": 3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fortune-telling"
+									},
+									"amount": 3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "psychology"
+									},
+									"amount": 3
+								}
+							],
+							"calc": {
+								"points": 15
+							}
+						},
+						{
+							"id": "a6a9017a-783d-4424-917b-8c952764647f",
+							"type": "trait",
+							"name": "Empathy (Sensitive)",
+							"reference": "DW41",
+							"userdesc": "As Empathy, but less reliable. The IQ roll for moodreading is at -3, and the skill bonus is only +1.",
+							"base_points": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "detect lies"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fortune-telling"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "psychology"
+									},
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "6f6cd2b8-c232-491e-86a4-524d3ce57e90",
+							"type": "trait",
+							"name": "Spirit Empathy",
+							"reference": "DW41",
+							"userdesc": "Works on spirits (magical, usually immaterial beings), golems, and anything else the GM decides is extraordinary enough to belong in this category. Your Influence skills (pp. 74-75) affect these entities normally. This doesn’t prevent evil spirits from seeking to harm you, but it makes it easier to detect their hostility",
+							"modifiers": [
+								{
+									"id": "110046ca-f474-4b43-877e-bd18510acdab",
+									"type": "modifier",
+									"name": "Specialized",
+									"reference": "B87",
+									"notes": "@Type: Angels, Demons, Elementals, Faerie, Ghosts, etc.@",
+									"cost": -50,
+									"disabled": true
+								},
+								{
+									"id": "05a618e6-ef79-49a6-9009-b2d3e13a12bb",
+									"type": "modifier",
+									"name": "Remote",
+									"reference": "P48",
+									"cost": 50,
+									"disabled": true
+								}
+							],
+							"base_points": 10,
+							"calc": {
+								"points": 10
+							}
+						}
+					],
+					"name": "Empathic Abilities",
+					"userdesc": "You have a “feeling” for a certain class of beings, which is useful for spotting imposters, brainwashing, etc., and for determining the attitudes of NPCs. When you first meet a suitable subject, or are reunited after an absence, you may ask the GM to roll against your IQ. He’ll tell you what you “feel” about that individual’s emotional state – friendly, frightened, hostile, hungry, etc. – and whether he or it is under some kind of control. On a failure, you get an uncertain or misleading answer.\n\nThere are several advantages in this category:",
+					"calc": {
+						"points": 35
+					}
+				},
+				{
+					"id": "97ac6262-b132-434e-995a-6d708e493bbc",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "1435e37d-abe6-4de1-8a5c-2c25639db773",
+							"type": "trait_container",
+							"open": true,
+							"children": [
+								{
+									"id": "f3b6b971-9a66-4d4b-8e7e-25a440f7498c",
+									"type": "trait",
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "DW41",
+									"levels": 1,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to Parry with @Melee weapon skill@",
+											"amount": 1
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "0e11130a-bc4f-4adf-b2e9-b692356eaae2",
+									"type": "trait",
+									"name": "Enhanced Parry (All parries)",
+									"reference": "DW41",
+									"levels": 1,
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "f3e65446-6b20-4b06-af0e-5c2ab7fdfefd",
+									"type": "trait",
+									"name": "Enhanced Parry (Bare hands)",
+									"reference": "DW41",
+									"levels": 1,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to Parry with bare hands",
+											"amount": 1
+										}
+									],
+									"can_level": true,
+									"calc": {
+										"points": 5
+									}
+								}
+							],
+							"name": "Enhanced Parry",
+							"calc": {
+								"points": 20
+							}
+						},
+						{
+							"id": "64e29aea-03eb-4b61-81ac-31290b0b1540",
+							"type": "trait",
+							"name": "Enhanced Block",
+							"reference": "DW41",
+							"levels": 1,
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "block",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "7134faae-1fe2-4d9e-b447-08325e199acd",
+							"type": "trait",
+							"name": "Enhanced Dodge",
+							"reference": "DW41",
+							"levels": 1,
+							"points_per_level": 15,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "dodge",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 15
+							}
+						}
+					],
+					"name": "Enhanced Defences",
+					"userdesc": "Combat Reflexes gives +1 to all defences for 15 points. Buy it before spending 15 or more points on Enhanced Defences!",
+					"calc": {
+						"points": 40
+					}
+				},
+				{
+					"id": "567dca92-9589-4576-aaef-495a01186f0d",
+					"type": "trait",
+					"name": "Extra Attack",
+					"reference": "DW42",
+					"userdesc": "You can attack more than once per turn, using different body parts. You can’t have more attacks than you have limbs, plus one for a bite.\n\nA normal human can buy just one Extra Attack, representing exceptional combat ability. This would allow him to stab with a sword in each hand (although his attack with the “off” hand would still be at -4), punch and kick, or whatever. An animal might have several Extra Attacks.\n\nYou cannot strike with some attacks while trading others for Aim, All-Out Defence, Change Posture, Concentrate, Move, or Ready manoeuvres. You can All-Out Attack (p. 175), in which case you have three options: make all of your attacks Strong, make all of them Determined, or use Double to add one more attack to your overall total.",
+					"levels": 1,
+					"points_per_level": 25,
+					"can_level": true,
+					"calc": {
+						"points": 25
+					}
+				},
+				{
+					"id": "faa8772c-cc63-47fd-9a33-ae792317c7c3",
+					"type": "trait",
+					"name": "Extra Life",
+					"reference": "DW43",
+					"userdesc": "You can come back from the dead! No matter how sure your foes were that they killed you, you didn’t really die. This may represent a favour from Fate, amazing luck (perhaps courtesy of The Lady, p. 303), or an overdose of narrative importance. Every time you come back, you use up one Extra Life – remove it from your character sheet and reduce your point total by 25 points.",
+					"levels": 1,
+					"points_per_level": 25,
+					"can_level": true,
+					"calc": {
+						"points": 25
+					}
+				},
+				{
+					"id": "0a8bfd43-7ead-49b0-b57c-6916f91f6d93",
+					"type": "trait",
+					"name": "Fearlessness",
+					"reference": "DW43",
+					"userdesc": "You’re difficult to frighten or intimidate! Add your level to your Will whenever you make a Fright Check (pp. 170-171) or must resist the Intimidation skill (p. 74). You also subtract your Fearlessness level from all Intimidation rolls made against you.",
+					"levels": 1,
+					"points_per_level": 2,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Fearfulness"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "9ceb934c-017e-44eb-abdf-c5714897575b",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "66d508fb-43d6-40f9-8b84-08cf5d05db3c",
+							"type": "trait",
+							"name": "Flexibility",
+							"reference": "DW43",
+							"userdesc": "You get +3 on Climbing rolls, and on Escape rolls to get free of ropes, handcuffs, etc. You may ignore up to -3 in penalties for working in close quarters (including many Explosives and Mechanic rolls).",
+							"base_points": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "climbing"
+									},
+									"amount": 3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "escape"
+									},
+									"amount": 3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "erotic art"
+									},
+									"amount": 3
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "in penalties may be ignored when due to close quarters",
+									"amount": -3
+								}
+							],
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "2674d3ee-06c7-439b-a5d1-528a1030de84",
+							"type": "trait",
+							"name": "Flexibility (Double-Jointed)",
+							"reference": "DW43",
+							"userdesc": "As above, but more so. You cannot stretch or squeeze yourself abnormally, but any part of your body may bend any way. You get +5 to Climbing, Escape, and attempts to break free. You may ignore up to -5 in penalties for close quarters",
+							"base_points": 15,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "climbing"
+									},
+									"amount": 5
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "escape"
+									},
+									"amount": 5
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "erotic art"
+									},
+									"amount": 5
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "in penalties may be ignored when due to close quarters",
+									"amount": -5
+								}
+							],
+							"calc": {
+								"points": 15
+							}
+						}
+					],
+					"name": "Flexibility",
+					"userdesc": "Your body is unusually flexible. This advantage comes in two levels:",
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "59c3b6d3-4a7f-4b98-b0fa-7784f684f3f5",
+					"type": "trait",
+					"name": "Gadgeteer",
+					"reference": "DW43",
+					"userdesc": "You’re a natural inventor. You can modify existing equipment and – given time and money – invent entirely new gadgets. This lets you design gadgets quickly and makes it easy to realise higher-TL innovations. Gadgeteers on the Disc aren’t comic-book super-inventors, though; your work takes days or months, and it requires money and equipment.",
+					"base_points": 25,
+					"calc": {
+						"points": 25
+					}
+				},
+				{
+					"id": "b48fcd39-eb23-436c-ae80-4d6e4952a96f",
+					"type": "trait",
+					"name": "High Manual Dexterity",
+					"reference": "DW43",
+					"userdesc": "You have remarkably fine motor skills. Each level (to a maximum of four) gives +1 to DX for tasks that require a delicate touch. This includes all DX-based rolls against Artist, Jeweller, Knot-Tying, Lockpicking, Pickpocket, Sewing, Sleight of Hand, and Surgery, as well as DX-based rolls to do fine work with Mechanic (e.g., on clockwork). This bonus doesn’t apply to IQbased tasks, to large-scale DX-based tasks, or to combat-related dice rolls of any kind.",
+					"levels": 1,
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "artist"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "jeweler"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "knot-tying"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "leatherworking"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "lockpicking"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "pickpocket"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sewing"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sleight of hand"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "surgery"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "machinist"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "mechanic"
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "197bb835-fc4d-47c3-8057-e685ab55d159",
+					"type": "trait",
+					"name": "High Pain Threshold",
+					"reference": "DW43",
+					"notes": "Never suffer shock penalties when injured",
+					"userdesc": "You are as susceptible to injury as anyone else, but you don’t feel it as much. You never suffer a shock penalty when you’re injured. In addition, you get +3 on HT rolls to avoid knockdown and stunning, and +3 to resist physical torture. The GM may let you roll at Will+3 to ignore pain in other situations.",
+					"base_points": 10,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on all HT rolls to avoid knockdown and stunning",
+							"amount": 3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to resist torture",
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "849bd320-f6a2-4a37-85d1-821fb6542469",
+					"type": "trait",
+					"name": "Indomitable",
+					"reference": "DW43",
+					"notes": "Impossible to influence through ordinary words or actions",
+					"userdesc": "You’re impossible to influence through ordinary words or actions. Those who wish to use Influence skills on you (see Influence Rolls, pp. 172-173) must possess a suitable Empathic Ability (p. 42): Empathy if you’re a human, dwarf, troll, etc.; Animal Empathy if you’re an animal; or Spirit Empathy if you’re a demon, ghost, etc. Everyone else – however convincing – fails automatically",
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "f77eb383-de6d-4909-b7ce-ba6c7174066d",
+					"type": "trait",
+					"name": "Less Sleep",
+					"reference": "DW43",
+					"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
+					"userdesc": "A normal human requires eight hours of sleep per night. Each level of this advantage – to a maximum of four – lets you get by with one hour less.",
+					"levels": 1,
+					"points_per_level": 2,
+					"can_level": true,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "a1e264b5-5717-4b3f-b96f-3eb2060c426d",
+					"type": "trait",
+					"name": "Lifting ST",
+					"reference": "DW43",
+					"userdesc": "You have exceptional lifting capacity. This can be a racial quality of species such as dwarfs (who have rugged frames) and trolls (who are made of rock), but anyone can buy up to three levels to represent practise in hauling loads. Add your Lifting ST to your ordinary ST when you determine Basic Lift (p. 28). Lifting ST also adds to ST in situations where you can apply slow, steady pressure (grappling, choking, drawing crossbows, etc.). Lifting ST does not boost ST (or Basic Lift) for the purposes of determining HP, throwing distance, damage inflicted by melee attacks or thrown weapons, or whether you can use a weapon without a penalty for being too weak.\n\nIf your SM is +1 or higher, you get a discount (-10% per +1 SM) on the cost of Lifting ST, just as for ordinary ST. You do notget a discount for the Quadruped disadvantage (p. 96), however",
+					"modifiers": [
+						{
+							"id": "3a979126-6b53-4293-825a-fd4679b99bdf",
+							"type": "modifier",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						}
+					],
+					"levels": 1,
+					"points_per_level": 3,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"limitation": "lifting_only",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "27e28cad-e654-4b56-a6c8-dae5bd1fa681",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "d601a8ce-6ae0-4b17-8e28-8dc8e1833d1e",
+							"type": "trait",
+							"name": "Daredevil",
+							"reference": "DW43",
+							"userdesc": "The Lady smiles on you when you take risks. Any time you take an unnecessary risk (in the GM’s opinion), you get +1 to all skill rolls. Furthermore, you may reroll any critical failure that occurs during such high-risk behaviour. For example, if a gang of bandits start firing arrows at you, and you crouch down behind a wall and return fire, you get no bonuses. If you vault the wall and charge, screaming, Daredevil provides all of its benefits.",
+							"base_points": 15,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to skill rolls any time you take an unnecessary risk (in the GM’s opinion)",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 15
+							}
+						},
+						{
+							"id": "c0d6786a-89e9-4da9-8a6a-16f713bc9816",
+							"type": "trait",
+							"name": "Extraordinary Luck",
+							"reference": "DW44",
+							"notes": "Usable once per 30 minutes of play",
+							"userdesc": "At limited intervals in a game session, you may reroll a single dice roll twice and take the best of the three rolls. You must declare that you’re using your Luck immediately after you roll the dice. Your Luck only applies to your own success, damage, or reaction rolls; or on outside events that affect you or your whole party; or when you’re being attacked (in which case you may make the attacker roll three times and take the worst roll!). “Ordinary” Luck lets you reroll something once per hour of play, Extraordinary Luck is usable every 30 minutes, and Ridiculous Luck works every 10 minutes. 15 points for Luck, 30 points for Extraordinary Luck, 60 points for Ridiculous Luck.",
+							"base_points": 30,
+							"calc": {
+								"points": 30
+							}
+						},
+						{
+							"id": "6ca1aa7e-588b-4125-a6a9-3c361caefb78",
+							"type": "trait",
+							"name": "Luck",
+							"reference": "DW44",
+							"notes": "Usable once per hour of play",
+							"userdesc": "At limited intervals in a game session, you may reroll a single dice roll twice and take the best of the three rolls. You must declare that you’re using your Luck immediately after you roll the dice. Your Luck only applies to your own success, damage, or reaction rolls; or on outside events that affect you or your whole party; or when you’re being attacked (in which case you may make the attacker roll three times and take the worst roll!). “Ordinary” Luck lets you reroll something once per hour of play, Extraordinary Luck is usable every 30 minutes, and Ridiculous Luck works every 10 minutes. 15 points for Luck, 30 points for Extraordinary Luck, 60 points for Ridiculous Luck.",
+							"base_points": 15,
+							"calc": {
+								"points": 15
+							}
+						},
+						{
+							"id": "6a233fb9-20d1-47e5-bd39-278aecfacbec",
+							"type": "trait",
+							"name": "Ridiculous Luck",
+							"reference": "DW44",
+							"notes": "Usable once per 10 minutes of play",
+							"userdesc": "At limited intervals in a game session, you may reroll a single dice roll twice and take the best of the three rolls. You must declare that you’re using your Luck immediately after you roll the dice. Your Luck only applies to your own success, damage, or reaction rolls; or on outside events that affect you or your whole party; or when you’re being attacked (in which case you may make the attacker roll three times and take the worst roll!). “Ordinary” Luck lets you reroll something once per hour of play, Extraordinary Luck is usable every 30 minutes, and Ridiculous Luck works every 10 minutes. 15 points for Luck, 30 points for Extraordinary Luck, 60 points for Ridiculous Luck.",
+							"base_points": 60,
+							"calc": {
+								"points": 60
+							}
+						},
+						{
+							"id": "bad54283-1d95-472a-8cb3-bb8ae2b40668",
+							"type": "trait",
+							"name": "Serendipity",
+							"reference": "DW44",
+							"userdesc": "Each level of Serendipity entitles you to one fortuitous coincidence per game session, details being up to the GM. For instance, one of the guards you need to talk your way past happens to be your cousin, or there’s a fast horse tied up in front of the bank just as you run outside in pursuit of fleeing robbers. If you have several levels, the GM may on occasion rule that a single implausible coincidence counts as some or all of your lucky breaks for a given session (e.g., the local blacksmith has multiple parts you need to complete your fancy rapid-fire siege engine, just lying around). You’re free to suggest serendipitous occurrences to the GM, but he gets the final say. Should he reject all your suggestions but fail to work Serendipity into the game session, you’ll get your lucky breaks next game session.",
+							"levels": 1,
+							"points_per_level": 15,
+							"can_level": true,
+							"calc": {
+								"points": 15
+							}
+						}
+					],
+					"name": "Luck Advantages",
+					"userdesc": "You were born lucky! The three traits in this category can be combined:",
+					"calc": {
+						"points": 135
+					}
+				},
+				{
+					"id": "4c9efdc8-79d4-4da5-892f-d3689ea59ea6",
+					"type": "trait",
+					"name": "Mad Medicine",
+					"reference": "DW44",
+					"userdesc": "You’re a brilliant inventor (thanks to the prerequisite Gadgeteer advantage), able to work with and even create all sorts of new and innovative devices – but in the field of medicine, your brilliance hurtles into the realms of insanity and heads for the horizon. Just for a start, you can perform ad hoc transplant surgery, using anarray of peculiar drugs and treatments to sidestep any boring questions of tissue rejection. You can also create exotic monsters from bits and pieces, or grow them from scratch if you have the patience. You probably apply your Gadgeteer ability in combination with other technical skills in support of your medical work.",
+					"base_points": 15,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gadgeteer"
+								},
+								"level": {
+									"compare": "at_least"
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"when_tl": {
+									"compare": "is",
+									"qualifier": 5
+								},
+								"prereqs": [
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Surgery"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Physician"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									}
+								]
+							}
+						]
+					},
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "0e47b735-af13-4738-a014-6fcf1040de80",
+					"type": "trait",
+					"name": "Magery",
+					"reference": "DW44",
+					"userdesc": "You’re magically adept. This advantage comes in levels. You must purchase Magery 0 (for 5 points) before buying higher levels (for another 10 points apiece).\n\nThis is basic “magical awareness”: a prerequisite for learning “proper” magic. It’s said that people with this ability have octagons as well as rods and cones in their eyes, enabling them to perceive octarine, the eighth colour of the spectrum, the “colour of magic” – but that may be a metaphor or something.\n\nThe GM makes a Sense roll (pp. 169-170) when you first see a magic item, and again when you first touch it. On a success, you intuitively know that the item is magical. A roll of 3 or 4 also tells you whether the magic is helpful or dangerous, and about how strong it is. With a similar roll, you sometimes get a “sense” about other supernatural things, though never any details; for instance, you might notice that a werewolf is “strange,” but that’s all. Individuals without Magery don’t get these rolls.\n\nIn addition, you can operate certain magical items – relatively safely and reliably, even – because you can sense the operational energies, read the invisible control runes, or whatever. You can also sense that invisible spirits (such as ghosts) are around, although you can’t locate them; you just get “a feeling.” And you usually perceive beings using the Unnoticed advantage (p. 48), as you’re used to seeing what’s truly there and aren’t so easily persuaded to ignore things.\n\nFurther levels of Magery make it much easier to learn and use magic. Add your Magery to your IQ when you learn Magic, Magical Form, and Thaumatology skills (and also spells, if the GM uses the optional rule on p. 203). For instance, if you have IQ 14, Magery 3 lets you learn those skills as though you had IQ 17. As well, your Magery level adds to Perception when you roll to sense magic items and beings, and it may benefit some rolls required when operating magical devices. Finally, higher Magery levels grant you access to more powerful spells and let you channel more energy into certain “variable” magics; see pp. 195-196.",
+					"modifiers": [
+						{
+							"id": "f13102fa-7b61-4b6f-b77e-dd8aff78a13a",
+							"type": "modifier",
+							"name": "No Spellcasting",
+							"reference": "DW44",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "be8ea847-64cb-4452-a4cd-3ff75866475a",
+							"type": "modifier",
+							"name": "Engineering Only",
+							"reference": "DW44",
+							"cost": -35,
+							"disabled": true
+						},
+						{
+							"id": "2a66c0f7-f729-40e9-8ef4-98c24587ce71",
+							"type": "modifier",
+							"name": "Non-Improvisational",
+							"reference": "DW45",
+							"cost": -30,
+							"disabled": true
+						}
+					],
+					"base_points": 5,
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "mp",
+							"amount": 0.2
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "25b0f19b-323b-4567-9f5a-661834af0640",
+					"type": "trait",
+					"name": "Medium",
+					"reference": "DW45",
+					"userdesc": "You can perceive and communicate with spirits, particularly spirits of the dead. You don’t see them visually, but you know when they’re nearby. You can speak with any spirit in your presence, provided that you share a language. You can also call spirits to you; there’s no guarantee that they’ll respond, but they’ll hear you if they’re the sort who pick up such things. This does not give you a reaction bonus with spirits, or any power over them.",
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "a519e561-3584-4a8a-a655-244291e7e81d",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "f0380b6d-82d5-4dde-92f0-815a9f340d2f",
+							"type": "trait",
+							"name": "Absolute Direction",
+							"reference": "DW45",
+							"userdesc": "You always know which way is hubwards, and you can retrace any path you’ve followed within the past month. This gives you +3 to Navigation skill. This knack works even underground and underwater",
+							"modifiers": [
+								{
+									"id": "940c9da3-6966-4ea6-9974-517614d0606b",
+									"type": "modifier",
+									"name": "Requires signal",
+									"reference": "B34",
+									"cost": -20,
+									"disabled": true
+								},
+								{
+									"id": "12730389-6652-4df8-8b34-ad078b76e408",
+									"type": "modifier",
+									"name": "3D Spatial Sense",
+									"reference": "B34",
+									"cost": 5,
+									"cost_type": "points",
+									"disabled": true,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "piloting"
+											},
+											"amount": 1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "aerobatics"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "free fall"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "navigation"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "hyperspace"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "navigation"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "space"
+											},
+											"amount": 2
+										}
+									]
+								}
+							],
+							"base_points": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "body sense"
+									},
+									"amount": 3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "air"
+									},
+									"amount": 3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "land"
+									},
+									"amount": 3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "sea"
+									},
+									"amount": 3
+								}
+							],
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "9c14d827-1ad2-49f3-8535-c1623b2fdb0b",
+							"type": "trait",
+							"name": "Eidetic Memory",
+							"reference": "DW45",
+							"userdesc": "Anyone may attempt an IQ roll to recall the general sense of past events, but you automatically succeed, and you can recall specific details by making an IQ roll.",
+							"modifiers": [
+								{
+									"id": "309120f1-8e25-46bf-ba83-6c998f4d9025",
+									"type": "modifier",
+									"name": "Photographic",
+									"reference": "B51",
+									"cost": 5,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"base_points": 5,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "b08b48c0-47a7-4314-903b-de4436c09212",
+							"type": "trait",
+							"name": "Lightning Calculator",
+							"reference": "DW45",
+							"userdesc": "You can do arithmetic in your head, instantly. You, the player, can always keep a calculator handy.",
+							"modifiers": [
+								{
+									"id": "6e674a5c-f7c3-411e-9f19-a0eb4f682c5b",
+									"type": "modifier",
+									"name": "Intuitive Mathematician",
+									"reference": "B66",
+									"cost": 3,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"base_points": 2,
+							"calc": {
+								"points": 2
+							}
+						},
+						{
+							"id": "ce30c5a6-3303-499d-b3da-e03c9137f5f4",
+							"type": "trait",
+							"name": "Photographic Memory",
+							"reference": "DW45",
+							"userdesc": "Like Eidetic Memory, but better – you automatically succeed at even the roll for specific details.",
+							"base_points": 10,
+							"calc": {
+								"points": 10
+							}
+						}
+					],
+					"name": "Mental Gifts",
+					"userdesc": "Your brain has some capability which most people lack:",
+					"calc": {
+						"points": 22
+					}
+				},
+				{
+					"id": "a69a2838-cd40-429f-8a19-e4ca1fffff7f",
+					"type": "trait",
+					"name": "Mind Shield",
+					"reference": "DW45",
+					"userdesc": "You have a “shield” that warns you of and defends against mental attacks. Add your level to IQ or Will whenever you resist a supernatural effect or magic spell that seeks to read or control your mind, “mental blasts,” and so on. Your shield also resists attempts to locate your mind; such abilities must win a Quick Contest against your Will + Mind Shield level to find you.\n\nYou may voluntarily lower your Mind Shield – say, to let a friend read your mind. Lowering or raising your shield is a free action, but it must take place at the start of your turn. Mind Shield does protect you while you are asleep or unconscious, unless you fell asleep or were knocked out while your shield was voluntarily lowered.",
+					"levels": 1,
+					"points_per_level": 4,
+					"can_level": true,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "d07e0ddd-5a57-44c0-b534-44b3e55f3c5b",
+					"type": "trait",
+					"name": "Night Vision",
+					"reference": "DW45",
+					"userdesc": "Your eyes adapt rapidly to darkness. Each level of this ability (maximum nine) allows you to ignore -1 in combat or vision penalties due to darkness, provided that there is some light.",
+					"levels": 1,
+					"points_per_level": 1,
+					"can_level": true,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "75da3ffa-81cf-4b9e-b4a4-4571482872bc",
+					"type": "trait",
+					"name": "Patchwork Man",
+					"reference": "DW45, DW46",
+					"userdesc": "You have a body constructed of parts from other bodies, rendered functional by Mad Medicine (p. 44). You might be an Igor or the product of some mad doctor’s researches. This permits you to purchase the occasional strange physical advantage, thanks to the ingenuity of your rebuilding. Acute Senses, High Manual Dexterity, and minor “racial” advantages (see Chapter 3) such as Claws or one or two levels of Damage Resistance (Tough Skin) would all be perfectly feasible, along with high ST or Lifting ST. The weirder your advantages, the more likely the GM is to insist that you should have, say, bad Appearance or Unnatural Features as well. In fact, Patchwork Man might also allow you to take odd physical disadvantages, such as Semi-Upright.\n\nYou’re also immune to Fright Checks and other psychological problems caused by the discovery of what a surgeon has done to you. You’ll never come round from the anaesthetic screaming “What have you done to me, you fiend?” – although if you’re an Igor, you may critique the stitching.",
+					"base_points": 10,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "High Pain Threshold"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									}
+								]
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Resistant to Disease"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 8
+										}
+									}
+								]
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Repairable"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Rapid Healing"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									}
+								]
+							}
+						]
+					},
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "8f52c9f1-3697-4834-b909-6a749690e131",
+					"type": "trait",
+					"name": "Perfect Balance",
+					"reference": "DW46",
+					"userdesc": "Under normal conditions, you can always keep your footing – no matter how narrow the walking surface (tightrope, ledge, tree limb, etc.) – without having to make a roll. If the surface is wet, slippery, or unstable, you get +6 on rolls to keep your feet. In combat, you get +4 to DX and DX-based skill rolls to keep your feet or avoid being knocked down. Finally, you get +1 to Acrobatics, Climbing, and Piloting skills.",
+					"base_points": 15,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on DX and DX-based skill rolls to keep your feet or avoid being knocked down in combat",
+							"amount": 4
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all rolls to keep your feet if the surface is wet, slippery or unstable",
+							"amount": 6
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "piloting"
+							},
+							"amount": 1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "acrobatics"
+							},
+							"amount": 1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "climbing"
+							},
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "ea8b55fe-a8a9-4b63-bc48-f2ecd7a3b58f",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "fb444049-f56d-4c31-9e67-ccd45d892d90",
+							"type": "trait",
+							"name": "Rapid Healing",
+							"reference": "DW46",
+							"userdesc": "Whenever you roll to recover lost HP (p. 187), you get +5 to your effective HT. You must have HT 10+ to take this.",
+							"base_points": 5,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "attribute_prereq",
+										"has": true,
+										"qualifier": {
+											"compare": "at_least",
+											"qualifier": 10
+										},
+										"which": "ht"
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to your effective HT whenever you roll to recover lost HP or to see if you can get over a crippling injury",
+									"amount": 5
+								}
+							],
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "7081f98a-960d-4ad2-aac9-5203282580d6",
+							"type": "trait",
+							"name": "Very Rapid Healing",
+							"reference": "DW46",
+							"notes": "When you roll to recover lost HP, a successful HT roll means you heal 2 HP, not 1",
+							"userdesc": "As above, but on a successful HT+5 roll, you heal two HP, not one. You must have HT 12+ to take this.",
+							"base_points": 15,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "attribute_prereq",
+										"has": true,
+										"qualifier": {
+											"compare": "at_least",
+											"qualifier": 12
+										},
+										"which": "ht"
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to effective HT when rolling to recover lost HP or to see if you can get over a crippling injury",
+									"amount": 5
+								}
+							],
+							"calc": {
+								"points": 15
+							}
+						}
+					],
+					"name": "Rapid Healing",
+					"userdesc": "You heal wounds quickly. This comes in two levels\n\nNeither level helps recovery from short-term injury effects such as stunning",
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "f9ca1701-0197-475d-b76e-06531b113d82",
+					"type": "trait",
+					"name": "Resistant",
+					"reference": "DW46",
+					"userdesc": "You’re naturally resistant or immune to diseases, poisons, or some specific concern. Resistant gives you a bonus on all HT rolls to resist the item in question. Total Immunity to a broad range of effects is usually limited to supernatural beings.",
+					"modifiers": [
+						{
+							"id": "bf280a67-e488-4a71-a90c-9dc566adcd06",
+							"type": "modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "9d0a156e-6a47-450a-a695-59920f642b44",
+									"type": "modifier",
+									"name": "All Poisons",
+									"reference": "B81",
+									"cost": 15,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "df4e4548-5978-43a5-ba38-1acbaead9779",
+									"type": "modifier",
+									"name": "All Diseases",
+									"reference": "B81",
+									"cost": 10,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "95a83382-1840-4824-b116-e378c6f814b8",
+									"type": "modifier",
+									"name": "@Specific Item: drug, disease, poison@",
+									"reference": "B81",
+									"cost": 5,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"name": "Type"
+						},
+						{
+							"id": "616fdc46-c0ac-4ac6-8aaf-77f4b7ff2ba7",
+							"type": "modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "b7b5b83b-6225-4feb-83ee-52cb72533224",
+									"type": "modifier",
+									"name": "+3 to all HT rolls to resist",
+									"reference": "B81",
+									"cost": 0.33,
+									"cost_type": "multiplier",
+									"disabled": true
+								},
+								{
+									"id": "0ce07da1-0712-4465-98c5-fb7e9975d462",
+									"type": "modifier",
+									"name": "+8 to all HT rolls to resist",
+									"reference": "B81",
+									"cost": 0.5,
+									"cost_type": "multiplier",
+									"disabled": true
+								},
+								{
+									"id": "568d217b-f340-4966-a69f-b4813e9cac82",
+									"type": "modifier",
+									"name": "Immunity",
+									"reference": "B81",
+									"cost": 1,
+									"cost_type": "multiplier",
+									"disabled": true
+								}
+							],
+							"name": "Resistance Level"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "fd8baeec-b613-4b97-8412-96701a7b39f3",
+					"type": "trait",
+					"name": "See Invisible",
+					"reference": "DW46",
+					"notes": "@Type: Magical, Spirit@",
+					"userdesc": "You can see objects or individuals that are normally truly invisible. Two types of “proper” invisibility exist in Discworld games: Magical, granted by spells and the like, and Spirit, possessed by certain immaterial, possibly extradimensional beings. Buy this advantage separately for each – See Invisible (Magical) or See Invisible (Spirit). Either variety allows you to perceive people using Unnoticed (p. 48), because Unnoticed doesn’t work very well on anyone who’s used to seeing what’s really there, and not just what they want to see.",
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "754f6418-7f88-4955-bb9e-2e2e02a5df00",
+					"type": "trait",
+					"name": "Silence",
+					"reference": "DW46",
+					"notes": "Bonuses help only when hearing is the only sense that can be used to detect you.",
+					"userdesc": "You move and breathe noiselessly. You get +2 per level to Stealth skill when you’re perfectly motionless, or +1 if moving – but only when your opponents must use hearing to detect you, such as in the dark.",
+					"modifiers": [
+						{
+							"id": "11a92b4d-003f-4dd9-97e3-9af9e0f75206",
+							"type": "modifier",
+							"name": "Dynamic",
+							"reference": "P76",
+							"cost": 40,
+							"disabled": true
+						}
+					],
+					"levels": 1,
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to Stealth when you are perfectly motionless",
+							"amount": 2,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to Stealth if moving (even in armor, etc.)",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "6abccfd2-9054-4a45-b076-cb98ba17aba1",
+					"type": "trait",
+					"name": "Single-Minded",
+					"reference": "DW46",
+					"userdesc": "You get +3 to success rolls for any lengthy mental task on which you concentrate to the exclusion of everything else if the GM feels that total concentration would help. You ignore everything else (roll vs. Will to avoid this), and you have -5 to all rolls to notice interruptions.\n\nThe GM may rule that some tasks (e.g., inventing, magic, and social activities) require divided attention. This trait has no effect in such situations.",
+					"base_points": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to rolls for any lengthy mental task you concentrate on to the exclusion of other activities, if the GM feels such focus would be beneficial",
+							"amount": 3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to all rolls to notice interruptions while obsessed with a task",
+							"amount": -5
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "2ed5877f-90b2-4f92-90f7-7d9eecbb9591",
+					"type": "trait",
+					"name": "Speak With Animals",
+					"reference": "DW46",
+					"userdesc": "You can converse with animals (as defined for Animal Empathy, p. 42). This requires a good explanation! It takes one minute to ask one question and get the answer – if the animal decides to talk at all. The GM may require a reaction roll (at +2 if you offer food). The quality of information you receive depends on the beast’s IQ and the GM’s decision on what it has to say. Insects might only convey “hunger” or “fear,” while a chimp or a cat might engage in reasonably intelligent discussion.\n\nCost depends on scope: “All animals” costs 25 points; “All land animals” (including birds, insects, and land-dwelling mammals and reptiles) or “All aquatic animals” (including amphibians, fish, molluscs, crustaceans, and cetaceans), 15 points; one class (e.g., “Mammals” or “Birds”), 13 points; one family (e.g., “Felines” or “Parrots”), 10 points; and one species (e.g., “House Cats” or “Macaws”),",
+					"modifiers": [
+						{
+							"id": "e9737ceb-63df-4e90-8f46-8a2e2461e45a",
+							"type": "modifier",
+							"name": "All aquatic animals",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "8bf5cc09-38bb-4683-9c19-9ec5f4e0560c",
+							"type": "modifier",
+							"name": "All land animals",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "ba3a8f45-ae28-4eeb-80fa-7350a2866078",
+							"type": "modifier",
+							"name": "@One class: Mammals, Birds, etc.@",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "41a5adf0-9be0-407f-b343-ef5827900337",
+							"type": "modifier",
+							"name": "@One family: Felines, Parrots, etc.@",
+							"cost": -60,
+							"disabled": true
+						},
+						{
+							"id": "021acdb3-1308-4a3b-b585-c5128d72650c",
+							"type": "modifier",
+							"name": "@One species: House Cats, Macaws, etc.@",
+							"cost": -80,
+							"disabled": true
+						}
+					],
+					"base_points": 25,
+					"calc": {
+						"points": 25
+					}
+				},
+				{
+					"id": "015ee0cc-6c68-4b58-8dd9-091df56b06c4",
+					"type": "trait",
+					"name": "Superior Staff",
+					"reference": "DW47",
+					"userdesc": "You’ve somehow acquired an unusually good wizard’s staff (see The Wizard’s Staff, pp. 192-193). This serves as a Magic Point “battery,” as usual, but each level of Superior Staff gives +1 to the number of Magic Points you can store in it. Moreover, you get +1 per level to Magic skill and all Magical Form skills (pp. 202-217), so long as you’re holding the staff.\n\nThe drawback is that the staff can be snatched away from you by an opponent. First, he has to use a grab attack (pp. 183-184) to get hold of it. Then he must win a Regular Contest of ST to take it from you. Fortunately, he can’t then turn it against you, even if he’s a wizard (see below).\n\nYou can take up to three levels of this advantage. There are legends of more powerful staffs, but they’re true one-offs, with built-in problems you wouldn’t want to know about. The only one to appear in the chronicles was carried by Coin the Sourcerer, which says it all.\n\nNormally, you can only purchase Superior Staff at character creation. Acquiring it once you’ve started a career in wizardry is a tricky and lengthy process at best. The traditional method for ruthless wizards is to take such a staff off another wizard (usually implying something homicidal). To benefit from this, you must then spend one month “detuning” your old staff and two months per level “attuning” to the new one, during which time you can’t do much else. Other wizards who realise what you’ve done will despise you if they have any morals, and envy you bitterly if they don’t.",
+					"modifiers": [
+						{
+							"id": "27514d6c-5b4f-4831-b28f-8f2295767045",
+							"type": "modifier",
+							"name": "Sapient Pearwood Staff",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "for reactions to other wizards if they are prone to jealousy",
+									"amount": -2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "for reactions to other wizards ",
+									"amount": 2
+								}
+							]
+						}
+					],
+					"levels": 1,
+					"points_per_level": 5,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magic"
+								},
+								"level": {
+									"compare": "at_least"
+								},
+								"specialization": {
+									"compare": "is",
+									"qualifier": "Wizard"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "mp",
+							"amount": 1
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "17e8743c-9cab-4063-8f67-c561a9b09dba",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "90a20cc8-467e-4153-874b-028412fc5eae",
+							"type": "trait",
+							"name": "Talent (Animal Friend)",
+							"reference": "DW47",
+							"userdesc": "Animal Handling, Falconry, Packing, Riding, Teamster, and Veterinary. The reaction bonuses it gives are from animals!",
+							"modifiers": [
+								{
+									"id": "4b4afac9-cefe-44ba-9b5d-4985cfaa26f1",
+									"type": "modifier",
+									"name": "Alternative Cost",
+									"cost": 1,
+									"affects": "levels_only",
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"levels": 1,
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "contains",
+										"qualifier": "animal handling"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "falconry"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "contains",
+										"qualifier": "packing"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "contains",
+										"qualifier": "riding"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "contains",
+										"qualifier": "teamster"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "contains",
+										"qualifier": "veterinary"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from ordinary animals",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "3054c7b3-ed36-46cd-9dc3-80ed1d5df694",
+							"type": "trait",
+							"name": "Talent (Artificer)",
+							"reference": "DW47",
+							"userdesc": "Engineer, repair skills (p. 80), and any other skill for making, building, or fixing practical stuff. Impresses customers.",
+							"levels": 1,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "armoury"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Carpentry"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Electrician"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Electronics Repair"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Engineer"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Machinist"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Masonry"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Mechanic"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Smith"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from any employer",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "0e8898fc-9758-40e2-8eee-86e2d2b9193e",
+							"type": "trait",
+							"name": "Talent (Born to Hang)",
+							"reference": "DW47",
+							"userdesc": "Larcenous skills (pp. 75-76), along with Disguise, Fast-Talk, Fortune-Telling, and Sleight of Hand. This is a gift for misdirection, deception, spotting loopholes, and working systems. It mostly garners reaction bonuses from any crooks who are “honest” enough to acknowledge an expert in their own field – who may be the only people who realise how good you are, at least until you get to court.",
+							"levels": 1,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "counterfeiting"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "filch"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "forced entry"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "forgery"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "holdout"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "pickpocket"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "smuggling"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "disguise"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fast-talk"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fortune-telling"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "sleight of hand"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from crooks who are \"honest\" enough to acknowledge an expert in their own field",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "a540e2ff-de09-45e6-915e-a67d5c68f5e0",
+							"type": "trait",
+							"name": "Talent (Born War-Leader)",
+							"reference": "DW47",
+							"userdesc": "Officer skills (p. 79), plus Leadership and Savoir-Faire (Military). Impresses veteran soldiers and warriors",
+							"base_points": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "tactics"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Strategy"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "land"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Strategy"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "naval"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intelligence Analysis"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Savoir-faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "military"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from veteran soldiers and warriors",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "1df4d409-efdb-429a-b631-db6fcde6ae18",
+							"type": "trait",
+							"name": "Talent (Gifted Artist)",
+							"reference": "DW47",
+							"userdesc": "Artistic and “craft” skills such as Artist, Jeweller, and Photography. Mostly impresses critics and connoisseurs.",
+							"levels": 1,
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Artist"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Jeweler"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Leatherworking"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Photography"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Sewing"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from buyers and critics",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "7bca614c-4f52-4e41-9a01-3a8fc7cfa162",
+							"type": "trait",
+							"name": "Talent (Healer)",
+							"reference": "DW47",
+							"notes": "Modern",
+							"userdesc": "Medical skills (p. 77) and Psychology. Impresses patients, not doctors!",
+							"modifiers": [
+								{
+									"id": "8a7f420e-72c4-4cbc-b6a1-e9672b7202c8",
+									"type": "modifier",
+									"name": "Alternate Benefit",
+									"notes": "Bonus to HT rolls for a specific patient and condition if treated full time.",
+									"disabled": true
+								},
+								{
+									"id": "660cd855-3088-4e77-bee9-15654cf1e514",
+									"type": "modifier",
+									"name": "Alternative Cost",
+									"cost": 1,
+									"affects": "levels_only",
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"levels": 1,
+							"points_per_level": 10,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Talent (Healer)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "Modern"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Diagnosis"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Esoteric Medicine"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "First Aid"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Pharmacy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Physician"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Physiology"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Psychology"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Surgery"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Veterinary"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Electronics Operation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Medical"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Expert Skill"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Epidemiology"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from patients",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "891d7cc5-4b28-44e5-9cdf-6ca3b6e0fb53",
+							"type": "trait",
+							"name": "Talent (Mathematical Ability)",
+							"reference": "DW47",
+							"userdesc": "Accounting, Astronomy, Cryptography, Engineer, Finance, Mathematics, and so on. You may also add your level to skill rolls for forms of “philosophy” that lean heavily on mathematics, and for magical studies that you can convince the GM require mathematical analysis (although those can be fiercely theoretical), but it doesn’t add to those skills in general, only to specific applications. Impresses mathematically inclined wizards and philosophers, and “creative” accountants.",
+							"modifiers": [
+								{
+									"id": "057f8673-2216-4f21-a752-a300a6883620",
+									"type": "modifier",
+									"name": "Alternate Benefit",
+									"notes": "Bonus to resist deception involving numbers",
+									"disabled": true
+								},
+								{
+									"id": "b2a013b0-2273-4c91-8dfa-50a3b5fa2715",
+									"type": "modifier",
+									"name": "Alternative Cost",
+									"cost": -2,
+									"affects": "levels_only",
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"levels": 1,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Accounting"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Astronomy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Cryptography"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Engineer"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Finance"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Market Analysis"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Mathematics"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Physics"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from engineers and scientists",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "a1898c70-0e94-4fbd-8016-4b0de3786f64",
+							"type": "trait",
+							"name": "Talent (Metalwork)",
+							"reference": "DW47",
+							"userdesc": "Armoury, Engineer (for any metal-related specialisation, which is most but not all of them), Jeweller, Mechanic, Metallurgy, Prospecting, and Smith. This is virtually universal at some level among dwarfs, and occasionally appears in individuals of other races. Impresses other skilled metalworkers.",
+							"base_points": 10,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "engineer"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "armoury"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "jeweller"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "mechanic"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "metallurgy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "prospecting"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "smith"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from skilled metalworkers",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "a5e665a5-e87d-455d-8f4f-19f20a088a55",
+							"type": "trait",
+							"name": "Talent (Musical Ability)",
+							"reference": "DW47",
+							"userdesc": "Any skill related to the composition or performance of music. Impresses most listeners.",
+							"levels": 1,
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Group Performance"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Conducting"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Musical Composition"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Musical Influence"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Musical Instrument"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Singing"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from audiences and critics",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "060a735e-5bed-4b8b-9347-229bd02939db",
+							"type": "trait",
+							"name": "Talent (Sense of the City)",
+							"reference": "DW47",
+							"notes": "@Town or City@",
+							"userdesc": "Area Knowledge, Current Affairs, Hidden Lore, and History relating to one specific town or city, and Urban Survival when in that place. Impresses watchmen, tour guides, and amateur historians there",
+							"levels": 1,
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Area Knowledge, Current Affairs, Hidden Lore, and History relating to one specific town or city, and Urban Survival when in that place",
+									"amount": 1
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from watchmen, tour guides, and amateur historians ",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "9e0672b6-27d0-40e4-b663-8a3e82b4e7e4",
+							"type": "trait",
+							"name": "Talent (Outdoorsman)",
+							"reference": "DW47",
+							"userdesc": "Camouflage, Fishing, Mimicry, Naturalist, Navigation, Survival, and Tracking. Impresses other outdoors types.",
+							"modifiers": [
+								{
+									"id": "254be33f-2141-4378-b967-c5d751c27942",
+									"type": "modifier",
+									"name": "Alternate Benefit",
+									"notes": "Bonus to HT rolls to avoid harm from failure of covered skills",
+									"disabled": true
+								},
+								{
+									"id": "2d095bbd-0918-4dfc-975e-de2ff3901fb2",
+									"type": "modifier",
+									"name": "Alternative Cost",
+									"cost": -3,
+									"affects": "levels_only",
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"levels": 1,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Camouflage"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Fishing"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Mimicry"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Naturalist"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Navigation"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Survival"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Tracking"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from explorers and nature lovers",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "451e962b-12f9-42b6-a76b-9df4ddb1a841",
+							"type": "trait",
+							"name": "Talent (Smooth Operator)",
+							"reference": "DW47",
+							"userdesc": "Influence skills (pp. 74-75), plus Acting, Carousing, Detect Lies, Leadership, Panhandling, Politics, and Public Speaking. Impresses other social operators, so long as you aren’t using it on them",
+							"modifiers": [
+								{
+									"id": "673ac6d5-88a0-46ff-9c61-a92a5908fd6d",
+									"type": "modifier",
+									"name": "Alternate Benefit",
+									"notes": "Bonus to resist covered skills",
+									"disabled": true
+								},
+								{
+									"id": "d7bc77f2-e124-4076-a8c1-e9845d9583c0",
+									"type": "modifier",
+									"name": "Alternative Cost",
+									"cost": -2,
+									"affects": "levels_only",
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"levels": 1,
+							"points_per_level": 15,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Acting"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Carousing"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Detect Lies"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Diplomacy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Fast-Talk"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Leadership"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Panhandling"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Politics"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Public Speaking"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Savoir-Faire"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Sex Appeal"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Streetwise"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 15
+							}
+						}
+					],
+					"name": "Talent",
+					"userdesc": "You have an aptitude for a set of closely related skills. “Talents” come in levels and give a bonus of +1 per level with all affected skills, even for default use. This effectively raises your attribute scores for the purpose of those skills only. Talents also impress other people who understand the skills; anyone who notices and can appreciate your gift reacts to you at +1 per level.\n\nYou may never have more than four levels of a given Talent. However, overlapping Talents can give skill bonuses (only) in excess of +4",
+					"calc": {
+						"points": 100
+					}
+				},
+				{
+					"id": "69e6dde7-12ad-42fb-b1aa-9229933346a3",
+					"type": "trait",
+					"name": "Tenure",
+					"reference": "DW49",
+					"userdesc": "You have a job from which you cannot normally be fired. You can only lose it (and this trait) as the result of extraordinary misbehaviour. Otherwise, your employment and salary are guaranteed for life. Senior wizards at Unseen University have this. In some places and times, this may tempt lower-ranking rivals to clear you off the ladder of seniority in a permanent fashion",
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "14fba2bc-6984-4e74-819d-c34a240d2bde",
+					"type": "trait",
+					"name": "True Faith",
+					"reference": "DW49",
+					"userdesc": "You have a profound religious faith that protects you from certain supernatural beings such as demons and vampires. To enjoy this protection, you must actively wield a physical holy symbol, chant, dance, or do whatever else is appropriate to your god. If you wish to use this ability in combat, you must choose the Concentrate manoeuvre each turn, and can do nothing else.\n\nFor as long as you assert your faith, no malign supernatural entity (GM’s judgement as to what this covers) may approach within one yard of you. If one is forced into this radius, it must leave by the most direct route possible. If it cannot leave without coming closer, it must make a Will roll. Success means it may run past you to escape, pushing you aside if necessary (but using only minimum force). On a failure, the monster cowers, helplessly; it cannot move, defend itself, or take any other action.\n\nTo keep True Faith, you must behave in a manner consistent with your religion. You should take a disadvantage such as Disciplines of Faith (p. 59) or Vow (p. 66), and stick to it. You don’t have to be kind or loving, though; there are plenty of stern and narrow-minded gods.",
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "e8463bf1-d9b2-4f2c-b758-33e4c1cb0d06",
+					"type": "trait",
+					"name": "Unfazeable",
+					"reference": "DW49",
+					"notes": "Exempt from fright checks. Reaction modifiers do not affect you.",
+					"userdesc": "Nothing surprises or frightens you! Intimidation (p. 74) doesn’t work on you, nor do magic spells that cause fear. The only thing on the Disc that can cause you to make a Fright Check (pp. 170-171) is becoming knurd (p. 187) – and even then, you get +8 to your roll.\n\nThe GM may wish to limit this to characters with very appropriate personal histories, or even ban it; PCs who refuse to be unnerved by anything don’t always fit in comedy games. However, there are people like this on the Disc.",
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "467b1282-9eeb-440d-adbf-fc9a903d4a22",
+					"type": "trait",
+					"name": "Unnoticed",
+					"reference": "DW48",
+					"userdesc": "You have the ability to not be noticed by normal people. This isn’t true invisibility – light doesn’t pass through you, and a fair number of beings can see you just fine – but it serves. This is basically what Death himself uses as he goes about his job. However, it doesn’t work – or at least not well – against anyone who’s accustomed to seeing things that “aren’t supposed to be there.”\n\nYou can turn this ability on and off at will with a one-second Concentrate manoeuvre. It works not only for you but also for anything you’re carrying up to Heavy encumbrance (p. 168). People get a chance to notice you, though, which requires a successful Will roll at -5. They try automatically when you first enter their view after at least five minutes out of their sight, or when you turn on your ability in their presence, and may be allowed to try again if you make loud noises, do something violent, etc., at the GM’s discretion. If you physically attack someone, your victim gets a roll to notice in time to defend himself, and automatically notices you after being hit once. Optionally, the GM can give very small children a bonus of +1 to +5 to all of these Will rolls, as they haven’t always learned to ignore inconvenient truths yet.\n\nUnnoticed fails automatically against gods, spirits, and anyone with any version of See Invisible (p. 46). Individuals with Magery (pp. 44-45) or Medium (p. 45) aren’t immune, but they roll at +2 to Will instead of at -5 (having both advantages doesn’t give a double bonus), and enjoy an additional +2 per Magery level; e.g., someone with Magery 0 or Medium rolls at Will+2, Magery 1 gives Will+4, and Magery 3 gives Will+8. If someone like this succeeds three times against you, your ability will never again work on him!\n\nThis supernatural advantage is mostly associated with a job as some kind of anthropomorphic personification, such as Death or a Tooth Fairy. Indeed, it “comes with the job”; anyone accompanying Death on his rounds, or standing in for him, gains the full benefits of his ability (under his control, if he’s present), while Tooth Fairies – who are perfectly ordinary young women in most respects – gain the ability while they are at work. At the GM’s option, anyone else who wants this ability may require an Unusual Background (below).",
+					"base_points": 70,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "will rolls for people with magery, per level, or medium to notice you",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "will rolls for people to notice you",
+							"amount": -5
+						}
+					],
+					"calc": {
+						"points": 70
+					}
+				},
+				{
+					"id": "0b5dfaac-5276-4fbb-9dd2-7d0ea085770d",
+					"type": "trait",
+					"name": "Unusual Background",
+					"reference": "DW49",
+					"notes": "@Description@",
+					"userdesc": "This is a “catchall” trait that the GM can use to adjust the point total of anyone with special abilities that aren’t widely available on the Disc; e.g., being a creature that has somehow fallen there from another world. Not every unusual character concept merits it!\n\nThe GM should only charge points when the character enjoys a tangible benefit. For instance, it would be unusual for a human to be raised by wolves, but unless this gave him capabilities that opponents wouldn’t expect or for which employers would pay a large premium, such as the ability to speak to wolves, it would merely be background colour, worth 0 points.",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "8e466756-43f7-4b0c-987f-d5ba96d8abc4",
+					"type": "trait",
+					"name": "Versatile",
+					"reference": "DW49",
+					"userdesc": "You’re extremely imaginative. You have +1 on success rolls for any task that requires creativity or invention. This includes most rolls against Artist skill, all Engineer rolls for new inventions, andall skill rolls made to use the Gadgeteer advantage (p. 43).\n\nVersatile (Inspiration Magnet): This variant of Versatile costs 5 points, just like the ordinary version – it’s more powerful but also highly erratic. Your capacity for original thought stems from the fact that your brain is a natural attractor for inspirations. Before making any skill rolls for a task that you or the GM think involves any significant creativity, roll 1d:\n\n1 – The inspirations fail you. You get no bonus at all.\n\n2, 3 – You get the usual +1.\n\n4, 5 – You get +2 to any relevant rolls, but the thing you produce is radical, unusual, or just too creative. Users or assistants require twice the usual time to get the hang of what you’ve created, and conventional observers and critics will react to it at -2.\n\n6 – Your brain overloads! You automatically produce something brilliant but wildly unorthodox, and only semi-relevant to your task – perhaps vaguely akin to what you set out to create, perhaps at a complete tangent, such as a new system of urban traffic management when trying to build a war chariot, or a new genre of publishing when attempting to develop a cosmological theory.\n\nYou cannot turn off this effect; your brain permanently fizzes with sensitivity. Also, because this advantage involves insight, the ideas that it grants tend to be fundamentally truthful. Using it to create propaganda or theories built on flawed foundations will produce bizarre results.",
+					"modifiers": [
+						{
+							"id": "d9016fd9-de3d-4864-bad8-041ddc230d4d",
+							"type": "modifier",
+							"name": "Insperation Magnet",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to creative rolls when a 2 or 3 is rolled",
+									"amount": 1
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to creative rolls when a 4 or 5 is rolled",
+									"amount": 2
+								}
+							]
+						}
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on any task that requires creativity or invention, including most rolls against Artist skill and all Engineer rolls for new inventions",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "f3429261-ee51-4db0-9f93-e933fc8111ea",
+					"type": "trait",
+					"name": "Voice of Command",
+					"reference": "DW49",
+					"userdesc": "When you tell someone to do something – in a particular tone of voice – they tend to obey. This affects everyone within eight yards, but only if they can hear you tolerably clearly (so noise, deafness, etc. can pose a problem) and understand your words (thus, complex instructions in a language which you or your subject speak at Broken levels might not work). Issuing the command requires a one-second Concentrate manoeuvre (p. 176) – or longer, if the GM thinks it’s complicated enough. Then roll a Quick Contest between your IQ and each possible victim’s Will. If you win, that person must obey; if he wins, he’s immune to your ability for the next 24 hours.\n\nThe effect will last anywhere from one second for a nighsuicidal instruction (“Attack that army!”) to a minute or two for something which the victim might well do anyway (“Give the doggy a biscuit.”). If the command is one which requires an extended duration, assume that it persists for up to a minute per point by which you won the Quick Contest.\n \nTo make your Voice of Command more effective, you can buy bonuses to your IQ roll. Every +2 to your roll costs 5 points. If the advantage affects only specific categories of victim, the GM might reduce its cost by 5 to 25 points, depending on how much this constrains the ability. For example, “Only affects humans” would be worth -5 points, “Only on trolls” or “Only on males” would be -10 points, and “Only affects redheads” would be -25 points.\n\nThis is a supernatural trait, but one or two slightly supernatural beings in the stories have acquired it. Gaspode the Wonder Dog (pp. 316-317) gains it because people assume that anything they hear from a talking dog must actually be their own idea. Still, it does require a justification, possibly involving an Unusual Background (pp. 48-49).",
+					"modifiers": [
+						{
+							"id": "b7daab0e-2405-402e-9e40-bd543a30bdc5",
+							"type": "modifier",
+							"name": "Only affects @Large Groups: Humans@",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "5e7f09a7-6874-425e-b9e3-47c854deb14d",
+							"type": "modifier",
+							"name": "Only affects @Moderately Sized Groups: Trolls, Males, etc.@",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "22043c0e-d428-447f-8571-1a4e4a1fe7ed",
+							"type": "modifier",
+							"name": "Only affects @Small Groups: Redheads@",
+							"cost": -25,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"base_points": 90,
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for IQ rolls to command everyone within 8 yards that can understand you",
+							"amount": 2,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 90
+					}
+				},
+				{
+					"id": "eeaf89be-5113-431e-9bcf-4e8ddb3ea9e4",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "bbeb621a-3bc1-493d-87ac-83f31c04ca35",
+							"type": "trait_container",
+							"children": [
+								{
+									"id": "3b78ca23-3d21-42a1-9c2f-bf8c528bd3f0",
+									"type": "trait",
+									"name": "Cold Resistance",
+									"reference": "DW50",
+									"userdesc": "You can go out in just a loincloth on Freezing days. If you wear lots of furs, you can treat Extreme Cold the way most people treat Freezing temperatures.",
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "e7de36bf-08a2-4f86-b6ef-8d3175cd1180",
+									"type": "trait",
+									"name": "Heat Resistance",
+									"reference": "DW50",
+									"userdesc": "You can remain fully active without penalty in Hot conditions, and you treat Very Hot temperatures as most people treat Hot.",
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								}
+							],
+							"name": "Cold or Heat Resistance",
+							"userdesc": "These perks refer to the rules for ambient temperature under Temperature Extremes (p. 191) and are equivalent to the 1-point versions of the racial advantage Temperature Tolerance (p. 92):",
+							"calc": {
+								"points": 2
+							}
+						},
+						{
+							"id": "8fa91804-c56c-4201-a1df-95a464522cb4",
+							"type": "trait_container",
+							"children": [
+								{
+									"id": "bbf75a35-4c92-47fd-b2b9-fa01d2d33014",
+									"type": "trait",
+									"name": "Fearsome Stare",
+									"reference": "DW53",
+									"userdesc": "You can use Intimidation by crossing your arms and glowering. This leaves no evidence of recorded threats or bruises, and scores lots for style.",
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "60d2f521-d7dc-4946-97a6-96406ec3e814",
+									"type": "trait",
+									"name": "Haughty Sneer",
+									"reference": "DW53",
+									"userdesc": "You can make bank tellers and waiters fawn over you just by peering down your nose and making a SavoirFaire (High Society) roll. This saves time and makes you look like a proper aristocrat.",
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "851c6a1a-2a18-43b4-a31a-54f2c9c5367d",
+									"type": "trait",
+									"name": "Street Swagger",
+									"reference": "DW53",
+									"userdesc": "Your casual walk and steely stare amount to use of Streetwise. If you’re good enough at the skill, you can walk through the Shades (pp. 252-253) unmolested.",
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								}
+							],
+							"name": "Wordless Influence",
+							"userdesc": "This is a category of perks, each of which enables you to use one Influence skill (pp. 74-75) as such without saying a word, thanks to your posture and manner, even if you don’t know the local language",
+							"calc": {
+								"points": 3
+							}
+						},
+						{
+							"id": "b436b630-b22b-4d47-9d87-5aed37954a6c",
+							"type": "trait",
+							"name": "Alcohol Tolerance",
+							"reference": "DW50",
+							"userdesc": "You can handle your drink. You get +2 on any HT roll related to drinking. (Trolls can take Sulphur Tolerance instead, for similar benefit.)",
+							"base_points": 1,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "on all HT rolls related to drinking",
+									"amount": 2
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "b745a81e-c13c-45b5-9e43-03f39d450ba4",
+							"type": "trait",
+							"name": "Archaic Training",
+							"reference": "DW50",
+							"notes": "@Description: Tool or Method@",
+							"userdesc": "You’ve learned to use old-fashioned tools or methods with one of your technological skills (p. 69). Each level of this perk lets you treat that skill as one TL lower whenever that would be convenient. This is handy not only because parts of the Disc are behind the times technologically, but also because lower-tech equipment is often easier to improvise.",
+							"levels": 1,
+							"points_per_level": 1,
+							"can_level": true,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "c51e2228-e248-4145-b0df-a831e14ef653",
+							"type": "trait",
+							"name": "Assasin in Good Standing",
+							"reference": "DW50",
+							"userdesc": "You’re a graduate of the Assassins’ Guild School (pp. 259-261) or have otherwise been granted Guild membership. (The GM may insist that you have skills and advantages enough to make this plausible.) If you kill someone for money in a place where the Guild operates, the Guild will make no objection so long as you can plausibly claim to have followed procedure. In addition, if you happen to kill somebody who’s on the Guild’s open target list, you can claim the fee.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "ad73e959-42eb-4045-84ff-15a08538d890",
+							"type": "trait",
+							"name": "Autotrance",
+							"reference": "DW50",
+							"userdesc": "You can enter a trance at will. This requires one minute of complete concentration and a successful Will roll, at -1 per additional attempt per hour. This trance gives +2 on rolls to contact spirits, etc. You must make another Will roll to break your trance; if you fail, you can try again every five minutes.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "631e8e72-d0c2-4fcd-b123-22a34885b535",
+							"type": "trait",
+							"name": "Blade-Proof Bare-Chestedness",
+							"reference": "DW50",
+							"userdesc": "When wearing an outfit that bares your legs, chest, or midriff, you get +1 to all active defences (pp. 180-181). In just a loincloth or otherwise skimpy wear, that becomes +2. Topless females get an extra +1. Total nudity gives no further bonus to defence, but adds +1 to your ground Move and +2 to water Move.\n\nThis perk does not make you immune to cold weather or public decency laws. It fits well with Benefits of the Barbarian Lifestyle (p. 58) – and if the GM chooses not to use that optional rule, he might also prohibit this perk.",
+							"modifiers": [
+								{
+									"id": "8bcc96e1-53ac-47cc-a4d7-325b14de4def",
+									"type": "modifier",
+									"name": "Skimpy wear",
+									"cost_type": "points",
+									"disabled": true,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										}
+									]
+								},
+								{
+									"id": "9e16bf8b-a5cc-495d-8155-dd6e2d0c0377",
+									"type": "modifier",
+									"name": "Female",
+									"cost_type": "points",
+									"disabled": true,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										}
+									]
+								},
+								{
+									"id": "76a3bed7-d8d8-4999-99bb-31dd20c56308",
+									"type": "modifier",
+									"name": "Nudity",
+									"cost_type": "points",
+									"disabled": true,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "move in water",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "basic_move",
+											"amount": 1
+										}
+									]
+								}
+							],
+							"base_points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Compulsive Barbarian Heroism"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 3
+												}
+											}
+										]
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Odious Personal Habit"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Compulsive Barbarian Heroism"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Compulsive Barbarian Heroism"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 3
+												}
+											}
+										]
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "dodge",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "parry",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "block",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "77383269-d8fc-4d67-bda8-186b6e0fa288",
+							"type": "trait",
+							"name": "Check the Exits",
+							"reference": "DW50",
+							"userdesc": "Whenever you enter a room, you reflexively look to see where the exits are – and if you’re going to be staying for long, you try to ensure that there’s at least one plausible escape route. This doesn’t mean that you respond instantly to threats (buy Combat Reflexes for that), or that your escape plan is perfect, but you need not specify that you have such a plan.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "f6ab745c-e448-496a-a695-cbd530a25a37",
+							"type": "trait",
+							"name": "Climatic Emphasis",
+							"reference": "DW50",
+							"userdesc": "On dark nights or during overcast and potentially stormy days, if you say something really significant and dramatic or portentous, or if you succeed with an Intimidation skill roll, you get a flash of lightning and a roll of thunder to emphasise the point. This has no specific game effects – although it may amplify the effects of Intimidation, at the GM’s option – but it’s stylish.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "95cc63d9-5b9c-4863-b65d-ef8812b88666",
+							"type": "trait",
+							"name": "Cobblestone Sence",
+							"reference": "DW50",
+							"userdesc": "You know the unique patterns and textures of a specific city’s cobblestones by touch. If you have bare feet or are wearing thin-soled footwear (no DR on the bottom!), then when walking or running along that city’s streets, you may roll against the associated Area Knowledge skill. Success tells you exactly where you are. You may attempt this as a free action once every 30 seconds.\n\nThis perk is known to work for Ankh-Morpork. Other cities may or may not have such recognisable cobbling. It wouldn’t be valid for a city where the streets have only been laid or re-laid recently, or one so organised that they all feel identical.",
+							"base_points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Area Knowledge"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									}
+								]
+							},
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "dabe26a0-62bb-415b-8880-d5d8d77d0a44",
+							"type": "trait",
+							"name": "Controllable Disadvantage",
+							"reference": "DW51",
+							"notes": "@Disadvantage@",
+							"userdesc": "You can inflict a specific disadvantage on yourself by taking 3d seconds and rolling against Will for a mental disadvantage or HT for a physical one. It then lasts until you choose to drop it. If you make multiple attempts, this roll is at -1 per previous attempt in the last hour, successful or not.\n\nValid options for mental disadvantages include Callous (which benefits Intimidation), Easy to Read (helpful for convincing others you’re not lying), and various forms of fake insanity. Berserk is prohibited. Physical disadvantages are mainly useful to weird people out or facilitate disguise: talking strangely to emulate Disturbing Voice, dislocating your shoulder to simulate One Arm, and so on.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "bc7ef32c-3f51-480c-9c4a-9586addf892f",
+							"type": "trait",
+							"name": "Crossbow Safety",
+							"reference": "DW51",
+							"userdesc": "You somehow carry full-sized or pistol crossbows on your back or slung from your belt, string drawn and a bolt ready to shoot, without wear or stress on bow or string – and more important, without serious accidents. As soon as you have the weapon in your hand, you can get a shot off. This may involve ingenious clips, good weapons maintenance, or just a lot of style.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "5cf78dfe-ed1e-4e46-abb4-ae538a7e1580",
+							"type": "trait",
+							"name": "Cutting-Edge Training",
+							"reference": "DW51",
+							"notes": "@Specialisation@",
+							"userdesc": "You’ve received instruction in a technological skill (p. 69) above your personal TL; e.g., a TL3 blacksmith might have Cutting-Edge Training (Armoury/TL4 (Melee Weapons)) to know how to make rapiers and smallswords. At the GM’s option, this perk might give access to two or even three closely related higher-tech skills. For example, a TL4 inventor who dabbles with steam power might know Engineer/TL5 (Steam Engines) and Mechanic/TL5 (Steam Engines) – and even Driving/TL5 (Steam Wagon) – with just one perk, because it’s all about one machine. Cutting-Edge Training (Physician and Surgery) is always permitted, as those two skills are closely linked.\n\nThis perk is cheaper than High TL (p. 31) for those with fewer than five specialisations. If someone gets Cutting-Edge Training in five areas, the GM may let him “trade in” those five perks for High TL 1.\n\nThis perk can have levels, one per TL. For example, Urn of Ephebe, in Small Gods, had three levels: while living in a TL2 society, he got a TL5 steam vehicle working.",
+							"levels": 1,
+							"points_per_level": 1,
+							"can_level": true,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "4cbb110e-e0ae-49fd-aafd-86391de41b1d",
+							"type": "trait",
+							"name": "Deep Sleeper",
+							"reference": "DW51",
+							"userdesc": "You can fall asleep in all but the worst conditions, and sleep through most disturbances. You never suffer any ill effects due to quality of sleep. You get an IQ roll to notice disturbances and awaken, just like anyone else; success is automatic if you have Combat Reflexes (p. 42).",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "cd179070-427b-40f3-91e9-f3efd1b2c4c8",
+							"type": "trait",
+							"name": "Divine News-Feed",
+							"reference": "DW51",
+							"userdesc": "Thanks to a gift from your god (well, a god), you can learn about the latest goings-on atop Cori Celesti (pp. 300-301) simply by concentrating for a second or two. This news usually takes the form of something that sounds like a plot summary from a bad soap opera, but it allows priests to track which other cults they should be friendly with and which they should disdain. Demonstrating this ability may be good for +1 or more to reactions from serious believers.\n\nThis gift is usually granted only to high-ranking priests. However, every now and again, a whimsical or careless deity inflicts it on some hermit or junior monk, to the consternation of the temple hierarchy.",
+							"base_points": 1,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from serious believers",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "6b24e9c9-aa06-4269-8684-0f6976c9c534",
+							"type": "trait",
+							"name": "Dual Ready",
+							"reference": "DW51",
+							"notes": "@Weapon@",
+							"userdesc": "You can use a single Ready manoeuvre to draw a weapon with either hand. Specialise by weapon combination in left-hand/righthand order; e.g., Dual Ready (Axe/Pick) lets you ready an axe in your left hand and a pick in your right.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "ce80d0d3-7ce2-4ec8-ac5b-c87de1f7964e",
+							"type": "trait",
+							"name": "Forgettable Face",
+							"reference": "DW51",
+							"userdesc": "You blend in. Your face is hard to pick out or remember. You get +1 to Shadowing in crowds, while others have -1 to rolls made to recognise you in a line-up, or even to recall meeting you! Forgettable Face is mutually incompatible with Unnatural Features (p. 30), Distinctive Features (p. 68), and Appearance above Attractive or below Unattractive.",
+							"base_points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Hideous"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Ugly"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Handsome (or Beautiful)"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Handsome (or Very Beautiful)"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Distinctive Features"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unnatural Features"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "shadowing"
+									},
+									"amount": 1
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to people trying to recognise you",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "5e24b6e9-0e66-450c-8f52-76a61dc45087",
+							"type": "trait",
+							"name": "Good with @Animal@",
+							"reference": "DW51",
+							"userdesc": "You have the Animal Empathy advantage (p. 42) for one specific species – dogs, horses, whatever.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "080aa903-b6fd-4fd3-8bea-46d7b95ca5c7",
+							"type": "trait",
+							"name": "Good with @Social Group@",
+							"reference": "DW51",
+							"userdesc": "You enjoy the Sensitive advantage (p. 42) – an IQ-3 roll to sense intent and +1 to Detect Lies and Psychology – when dealing with one specific group: children (anyone under 12 years of age), old people (adults over 65), wizards, witches, etc. “Men” and “women” are much too broad for this purpose, as are “dwarfs,” “trolls,” and “undead,” although some less common nonhuman races might be allowed.",
+							"base_points": 1,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to detect lies and psychology",
+									"amount": 1
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to sense intent",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "e350773a-174d-48e8-b73e-660a3a04a170",
+							"type": "trait",
+							"name": "High-Heeled Heroine",
+							"reference": "DW51",
+							"userdesc": "You can run, climb, and fight while wearing high heels without suffering any special penalty for “bad footing.” You can also kick with such footwear, dealing thrust-1 large piercing damage, plus unarmed skill bonuses.",
+							"base_points": 1,
+							"weapons": [
+								{
+									"id": "c31e8127-9e68-40b9-bec6-da98fe28a587",
+									"type": "melee_weapon",
+									"damage": {
+										"type": "pi+",
+										"st": "thr",
+										"base": "-1"
+									},
+									"usage": "Heel Kick",
+									"reach": "1",
+									"calc": {
+										"damage": "thr-1 pi+"
+									}
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "2a403b60-f653-4aee-ab34-5f511784a18e",
+							"type": "trait",
+							"name": "Honest Face",
+							"reference": "DW51",
+							"userdesc": "You look honest, reliable, or generally harmless. People who don’t know you tend to pick you as the one to confide in – or not pick you, if they’re seeking a potential criminal or troublemaker. You won’t be spot-checked by gate guards unless they have another reason to suspect you, or unless they’re truly choosing at random. You have +1 to Acting skill for the sole purpose of “acting innocent.” None of this has anything to do with the truth about you!",
+							"base_points": 1,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to trained Acting skill for the sole purpose of \"acting innocent\"",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "10ac5f45-326d-4971-a586-41e49f6cebbe",
+							"type": "trait",
+							"name": "Hyper-Specialisation",
+							"reference": "DW51",
+							"notes": "@Hyper-Specific Topic: Thaumatology, Philosphy, Theology@",
+							"userdesc": "You’re an expert in an extremely specific area. You must specialise by one IQ-based “knowledge” skill, or magical or philosophical “theory” skill, and then further choose some obscure speciality that takes at least three words to describe. You get +5 to rolls regarding that specific topic. Examples include Hyper-Specialisation (Thaumatology: Left-Handed Narrativium Charm Inversions), (Philosophy (Agatean): Aesthetic Butterfly Related Dreaming), and (Theology (Omnian): Angelic Choreographic Geometries). These may seem useless, but smart players can be surprisingly clever with such things.",
+							"base_points": 1,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "for rolls on the specific topic",
+									"amount": 5
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "e5051d18-309e-47f6-ae4c-1b242d244745",
+							"type": "trait",
+							"name": "Improvised Weapons",
+							"reference": "DW52",
+							"notes": "@Weapons Skill",
+							"userdesc": "You’re accustomed to fighting with the first object that comes to hand. This lets you avoid any penalties the GM assesses for using such improvised weapons in combat. You must select one weapon skill (pp. 77-78) to which this perk applies (buy it several times to use it with multiple weapon skills) – or choose Brawling (p. 82) or Karate (p. 83) to avoid penalties from improvised fist loads.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "51df3617-184a-48cb-84da-4e6c4f42d276",
+							"type": "trait",
+							"name": "Longevity",
+							"reference": "DW52",
+							"notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+							"userdesc": "You have a significantly longer lifespan than most humans – meaning anything from “you’ll be hale and hearty at 80” to “you don’t physically age.” Details vary by race, and several nonhuman races have this as an innate quality. Longevity has little direct effect in play, but it does grant you immunity to weird magical ageing effects, and can help you explain remarkably broad experience or memories of historical events that most people only read about in books.",
+							"base_points": 2,
+							"calc": {
+								"points": 2
+							}
+						},
+						{
+							"id": "5600cb54-6c98-4e08-af1f-151ab9ef1a2c",
+							"type": "trait",
+							"name": "No Hangover",
+							"reference": "DW52",
+							"userdesc": "You get drunk just like anybody else (pp. 187- 188), but you always wake up feeling fine the next day. This doesn’t eliminate the immediate consequences of drinking – just the after-effects. Persistently acting cheerful and hearty while your friends are groping for the Klatchian coffee, or telling others not to fuss about their “imaginary” hangovers, can qualify as an Odious Personal Habit (p. 29).",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "1b20886c-1c8e-4d28-a005-c1e91821f88f",
+							"type": "trait",
+							"name": "Off-Hand Training",
+							"reference": "DW52",
+							"userdesc": "You’ve practised a particular skill (usually but not necessarily a combat skill) with your “off” hand enough that you can ignore the -4 for using that hand; see Handedness (p. 29). This extends to defences based on that skill. You must specialise by skill; any skill qualifies, provided that it has applications that normally use only one hand.\n\nThis is cheaper than Ambidexterity (p. 41) for those with fewer than five specialisations. If someone is dedicated enough to buy the perk five times, the GM should let him “trade in” the points for full-fledged Ambidexterity.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "ffed46cd-5ad4-4546-8c5f-5cd0adaf9693",
+							"type": "trait",
+							"name": "Oggham Reader",
+							"reference": "DW52",
+							"userdesc": "You can read the Oggham runes (p. 17). Normally, literacy in a language that used to use Oggham implies command of a more modern script (dwarfs use human scripts a lot these days, even for their own languages), and you’ve got that, but you’ve also acquired knowledge of this ancient writing.",
+							"base_points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Language"
+										},
+										"level": {
+											"compare": "at_least"
+										},
+										"notes": {
+											"compare": "is",
+											"qualifier": "At least Accented-level literacy(p. 31) in one appropriate language."
+										}
+									}
+								]
+							},
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "c5868263-5543-450d-bfa6-deaa45611d3b",
+							"type": "trait",
+							"name": "Penetrating Voice",
+							"reference": "DW52",
+							"userdesc": "You can really make yourself heard! In situations where you want to be heard over noise, others get +3 to their Hearing rolls. At the GM’s option, you may get +1 to Intimidation rolls if you surprise someone by yelling or roaring.",
+							"base_points": 1,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to intimidation rolls if you surprise someone by yelling or roaring",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "08f25190-752a-4ee4-a1cd-553934484bee",
+							"type": "trait",
+							"name": "Secret Name",
+							"reference": "DW52",
+							"userdesc": "A wizard who wants to transform another wizard by magic must know his subject’s correct name; see Arbitrary Limitations (pp. 193-194). This perk means that you’ve succeeded in keeping your true, full name secret, to protect yourself from transformation magic. It’s known only to you, and perhaps to a few trusted friends or relations (your choice). The only snag is that if you ever suffer some kind of magical affliction and can’t fix it yourself, you might have to give your name away to another wizard anyway, so that he can help.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "aa491f8a-c31c-4841-813b-294b8695ca3a",
+							"type": "trait",
+							"name": "Self-Styling Hair",
+							"reference": "DW52",
+							"userdesc": "Your hair has the supernatural ability to adopt any style by itself, in response to your mood. This is helpful because it will automatically look right on social occasions (provided that you genuinely want to look right), and it will get out of the way within seconds if things get dangerous. You can’t exert fine conscious control over it, though, and it can’t exert any significant strength.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "2e930fa4-bce2-4f9f-b366-09ce82783aec",
+							"type": "trait",
+							"name": "Statuesque",
+							"reference": "DW52",
+							"userdesc": "Whatever your appearance in general, you have an excellent figure. You count as one Appearance level higher than usual when dealing with someone who judges purely by shape and not at all by face, when you’re glimpsed at a distance while dressed appropriately, or when you can get away with wearing a veil combined with closefitting or revealing clothes.\n\nThis perk is mutually incompatible with all the traits under Build (p. 29). Its benefits work only on other members of your species – and dwarfs can pick it only if they’re the modern, outrageous sort who admit what sex they are. Don’t bother with Statuesque if you’re Very Beautiful or Very Handsome; if you’re that good-looking, you already have a perfect figure.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "f179b346-b972-4b32-8369-79cedf466295",
+							"type": "trait",
+							"name": "There on Call",
+							"reference": "DW52",
+							"userdesc": "If your current paying employer calls out your name and you could reach his side within two seconds, or if you’re in his home and an unexpected visitor knocks on the front door, you can appear behind your boss with a “Yes, master?” (or more likely a “Yeth, mathter?”, this largely being the province of Igors) or open the door within seconds, as appropriate. You automatically avoid any traps or pitfalls that might get in your way, and no one can ever work out how you accomplished this.\n\nYou cannot use this perk for any sort of combat advantage. You just do your job right.",
+							"base_points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Traps"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Stealth"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Savoir-Faire"
+										},
+										"level": {
+											"compare": "at_least"
+										},
+										"specialization": {
+											"compare": "is",
+											"qualifier": "Servant"
+										}
+									}
+								]
+							},
+							"calc": {
+								"points": 1
+							}
+						},
+						{
+							"id": "bde4094d-9b85-4f2a-a891-9c7bc0336158",
+							"type": "trait",
+							"name": "Understands the Librarian",
+							"reference": "DW53",
+							"userdesc": "The Librarian (pp. 333-335) insists that orang-utans have a rich and complex language, but as it has only one word (“ook”), humans can’t really master it. It also happens to be all he speaks, although he can understand Morporkian and numerous other languages. Hence, many wizards and servants at Unseen University (and a few other people) have learned to understand what he says, although they don’t try to speak his language. The GM may rule that especially complex or technical concepts require gestures or visual illustration.",
+							"base_points": 1,
+							"calc": {
+								"points": 1
+							}
+						}
+					],
+					"name": "Perks",
+					"userdesc": "“Perks” are minor advantages that cost just 1 point apiece. They give small benefits in highly specific situations. Some let you pull off unusual tricks using particular skills, others represent special permissions, and still others simply let you look really cool.\n\nThe following perks are merely examples; many others are possible. When inventing new ones, remember that perks cost only 1 point. They shouldn’t give too great a benefit. If something can be represented using ordinary advantages or skills, it’s not a perk.",
+					"calc": {
+						"points": 37
+					}
+				}
+			],
+			"name": "Advantages",
+			"userdesc": "An “advantage” is a useful trait that gives you a mental, physical, or social “edge.” Several examples have appeared already; e.g., superior Appearance and above-average Wealth. This section details many more.\n\nEach advantage has a cost in points. This is fixed for some, while others are bought in “levels,” at a cost per level (e.g., Acute Vision costs 2 points/level, so if you want Acute Vision 6, you pay 12 points). Advantages with “Variable” cost are more complicated; read the advantage description for details.\n\nSome advantages have prerequisites: traits you must purchase separately before you can buy the advantage. Where skills are noted as prerequisites, you need only one point in the skill if no minimum level is specified – although such advantages are often more useful if you’re really good at the skill.\n\nThe GM has the final say as to whether a particular advantage suits a given character concept.\n\nLimited Advantages: Some advantages have variant, restricted forms. For examples, see Magery (pp. 44-45) and Speak With Animals (p. 46). These are explained where they appear, with reduced point costs to reflect lower utility",
+			"calc": {
+				"points": 889
+			}
+		},
+		{
+			"id": "6f3e0c2d-b9bb-46b0-8700-b7db69c737dc",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "93be0318-f7aa-42b5-9382-5ae3d32b5636",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "e2390a36-7eef-4477-8bfb-c8247ab99b51",
+							"type": "trait",
+							"name": "Cannot Speak",
+							"reference": "DW56",
+							"userdesc": "You can make vocal sounds (maybe bark, growl, trill, etc.), but your speech organs are incapable of the subtleties of language. You may still have the Mimicry skill (though not the Speech specialisation), the Voice advantage, or the Disturbing Voice disadvantage. Most animals have this trait",
+							"base_points": -15,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "stuttering"
+										}
+									}
+								]
+							},
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "b83c863f-3709-4c69-b71a-70eb95eccb4b",
+							"type": "trait",
+							"name": "Mute",
+							"reference": "DW56",
+							"userdesc": "You cannot vocalise at all. All communications with others must be non-verbal: writing, gestures, telepathy, etc. You cannot have any other voice-related traits.",
+							"base_points": -25,
+							"calc": {
+								"points": -25
+							}
+						}
+					],
+					"name": "Cannot Speak",
+					"userdesc": "You have a limited capacity for speech. This comes in two levels:",
+					"calc": {
+						"points": -40
+					}
+				},
+				{
+					"id": "c70d7794-5187-4bfd-a6fa-32b7c62164d0",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "0223dc27-92b2-49c3-aa8c-9bc8847a940f",
+							"type": "trait",
+							"name": "Code of Honor (Academic)",
+							"reference": "DW56",
+							"notes": "Pursue learning diligently, and never lie about it. Respect felllow academics and their work. Only conceal knowledge if lives are at stake. Acknowledge your sources. ",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "34d52822-2801-4836-9007-7b9c60314275",
+							"type": "trait",
+							"name": "Code of Honor (Assassins')",
+							"reference": "DW56",
+							"notes": "As a member of the Assassins’ Guild (pp. 259-261) – not a vulgar hired killer – you must behave with courtesy to other gentlemen, keep your word to fellow Guild members (and in general, when not performing your Guild duty), and never kill except for hire or in self-defence. If you take an advance payment, complete the mission or return it with an apology. Killing a target’s guards, let alone mere servants, is questionable manners; it can be forgiven in exceptional circumstances, but it’s a matter for stern self-criticism, as bypassing guards with stealth and agility is always preferable. Never employ gross or clumsy methods; you disdain explosives in any great quantity (a small charge, perfectly placed, might show just enough style), or heavy weapons. Offer a personal service; you might possibly deal with two or three problems at the same time, but you refuse bulk orders. Nor will you shoot down a victim in the street like a crude thug; you deliver at home or at the office, and always leave a receipt. Wear black or very dark colours, unless there’s some clear off-duty reason not to; this inspires respect (and helps you hide in shadows, although solid black isn’t perfect for that), but it can also attract the attention of lower-class persons who regard killing an Assassin as something to boast about.",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "b6f16c20-96e8-47d9-9085-8f903e6b742c",
+							"type": "trait",
+							"name": "Code of Honor (Chivalry)",
+							"reference": "DW56",
+							"notes": "Never break your word. Never ignore an insult. Defend all ladies (women of Status 1+). Always fight fair, and accept any challenge to arms from anyone of equal or higher Status. Serve your lord faithfully in all things.",
+							"base_points": -15,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "58efff4d-81b8-40cd-831d-ee82fd180c2a",
+							"type": "trait",
+							"name": "Code of Honor (D'reg's)",
+							"reference": "DW57",
+							"notes": "Seek revenge for insults. Protect your sworn friends. If you take in a guest or are a guest, treat the hospitality as sacred for exactly 72 hours. In battle, when someone says “Charge!” you charge. However, you don’t have to fight fair, and you aren’t automatically sworn to loyalty to anyone – not even family.",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "2e22343d-ff0d-4fce-b002-12a04d33d6f1",
+							"type": "trait",
+							"name": "Code of Honor (Dark Lord's)",
+							"reference": "DW56",
+							"notes": "Aim to win in a way that demonstrates your superiority, and only break your word in large matters. Never ignore an insult to yourself, your schemes, or the symbols of your rule – rant a lot at whoever is responsible, and then take a complicated revenge. (This Code only applies between dark lords and hero types, though; disrespect from peasants calls for a sneer and overwhelming force, not a rant.) Always take advantage of opponents in dramatic ways; if your enemies are defeated and helpless, engage in some token gloating and then ignore them while you get on with important matters. Use overcomplicated death-traps and ornate, flared, barbed, and smokeblackened blades. Talk to upper-class or good-looking prisoners and guests with florid courtesy, but treat people you find attractive as interesting decorations, never as your equals. Compliment them on their looks by leering at them; it shows that you care. Provide visiting heroes who aren’t yet scheduled for the death-trap with comfortable lodgings, submissive servants, and a change of clothes.",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "2c223afb-9cdf-4e80-a04d-bea453d7d7bb",
+							"type": "trait",
+							"name": "Code of Honor (Gentleman's)",
+							"reference": "DW57",
+							"notes": "Never break your word. Never ignore an insult to yourself, a lady, or your flag (insults must be wiped out by an apology or a duel, not necessarily to the death!). Never take advantage of an opponent – weapons and circumstances must be equal (except in open war). All this applies only between gentlemen; discourtesy from anyone of Status 0 or less calls for a whipping, not a duel!",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "1ce95320-696e-4936-a205-2213d4489469",
+							"type": "trait",
+							"name": "Code of Honor (Klatchian)",
+							"reference": "DW57",
+							"notes": "Never break your word. Never ignore an insult to yourself, a family member, or your tribe (insults must be wiped out by an apology or a duel, not necessarily to the death!). If you take in a guest or are a guest, treat the hospitality as sacred for exactly 72 hours.",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "6f205f28-5ee7-417c-a78b-24536ceba735",
+							"type": "trait",
+							"name": "Code of Honor (Igor's)",
+							"reference": "DW57",
+							"notes": "This is a form of Professional Code (below) that just about demands the skills, tolerance, and detachment of a true Igor (pp. 140-141). Obey instructions, never complain, and get the job done. Accept routine physical abuse from your employer with calm resignation, and don’t cave in to screaming angry villagers – although you may whimper and cower a bit for the look of the thing. You aren’t obliged to die for your master, though. If and when his career approaches a catastrophic climax, you may collect enough knick-knacks from his collection to cover wages owed and quietly depart by the back door.",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "e40aca2d-ea10-4cf5-b257-ed9f0070a337",
+							"type": "trait",
+							"name": "Code of Honor (Pirate's)",
+							"reference": "DW57",
+							"notes": "Always avenge an insult, regardless of the danger. Your buddy’s foe is your own. Never attack a fellow crewman or buddy except in a fair, open duel. Anything else goes. Similar Codes often appear among bandits, Hublander tribesmen, etc",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "976aa8b7-7b4d-4fa6-9a7c-b7151936fcea",
+							"type": "trait",
+							"name": "Code of Honor (Professional)",
+							"reference": "DW57",
+							"notes": "Adhere to the ethics of your profession; always do your job to the best of your ability; support your guild, union, or professional association.",
+							"userdesc": "Many professions have formalised ethics, which some professionals treat as a matter of honour. This generally involves obeying rules of procedure, paying professional membership dues, not undermining a fellow professional who’s playing by the rules himself, and only ripping off customers in the polite, time-honoured fashion.",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "f441fa13-14c9-4709-bba3-6f85ce986981",
+							"type": "trait",
+							"name": "Code of Honor (Soldier's)",
+							"reference": "DW57",
+							"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an ordinary soldier should look out for his pals and take care of his kit. Be willing to fight and die for the honour of your unit, service, and country. Follow orders. Obey the “rules of war.” Treat an honourable enemy with respect (a dishonourable one deserves a knife). Wear the uniform with pride.",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "dba2bfe5-2f10-45c7-941d-80d40c03e822",
+							"type": "trait",
+							"name": "Code of Honor (Watchman's)",
+							"reference": "DW57",
+							"notes": "Serve your community by upholding the law – and most importantly, by catching the bad guys. Wear the uniform with pride. Defend the honour of the watch. Protect and assist your fellow officers; when they call for assistance, run to help. Don’t embarrass your buddies, and protect them if they make mistakes, but if they’re knowingly damaging the watch, they forfeit your loyalty. While all this sometimes requires bending the written rules, don’t lose track of the objective.",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "117d9f3b-80f5-4cb4-9359-30513129d4f6",
+							"type": "trait",
+							"name": "Code of Honor (Wise-Woman's)",
+							"reference": "DW57",
+							"notes": "This Professional Code (above) is mostly found among witches of the more ethical sort. It’s chiefly a set of principles for a medical practitioner, the main components of which are “Do your best for your patients,” “Only charge what people can afford,” and “What’s said in the sickroom stays in the sickroom.” The last applies double to the delivery room; any working midwife hears things yelled that the mother won’t want repeated later. This rule is the one thing that limits some witches’ gossiping. ",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						}
+					],
+					"name": "Code of Honor",
+					"userdesc": "You take pride in following a set of “honourable” principles. The specifics can vary. You’ll do nearly anything, maybe even risk death, to avoid looking “dishonourable.”\n\nThe point value of a Code of Honour depends on how much trouble it gets you into, and on how arbitrary and irrational its requirements are. An informal Code, or one that shouldn’t ever get you killed, is worth -5 points. A formal Code, or one that often sends you into danger, is worth -10 points. A highly formal Code that regularly jeopardises your life is worth -15 points.\n\nMany social classes and groups have an associated Code of Honour. This doesn’t necessarily mean that all or even most such people actually possess the disadvantage – although highminded and idealistic ones usually will, and many others may follow it at quirk level (p. 66), obeying it when convenient but not at serious risk to their lives. On the other hand, openly disregarding your group’s Code is a good way to become a social outcast; a “gentleman” who fails to act the part may be expelled from his club and possibly sent far away by his family, while a watchman who doesn’t watch his colleagues’ backs may find his gear vandalised and can’t expect much help when he gets into trouble. Failing to pay lip-service to a Code can be the basis for a negative Reputation (p. 34).\n\nAs the Disc is a realistic-comedy world, many people who espouse strict Codes come across as stiff-necked, pompous, and even stupid. However, the sincere ones get credit for trying – and there are those who believe that sometimes, when Narrative Causality (pp. 8-9) kicks in, living by one of the stricter Codes can save your life. The hero will win, but only if he acts like a hero; the dark lord will live to scheme another day, but only if he plays his part. Certainly, a Code may well mean allowing opponents a better chance provided that they played by the rules as well, whether this is a soldier treating prisoners better if they, too, recognise the Soldier’s Code, or a dark lord putting a proper barbarian hero in a fallible death-trap when he’d outright massacre mere rebellious peasants. Thus, living by a Code can save your life.",
+					"calc": {
+						"points": -100
+					}
+				},
+				{
+					"id": "b846e7e1-1745-46a8-bcf7-cfa3c8ccd649",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "771408ba-24a0-4e02-9488-088b95b2c77a",
+							"type": "trait",
+							"name": "Compulsive Barbarian Heroism",
+							"reference": "DW58",
+							"userdesc": "You live the loincloth-andbroadsword life. Your preferred solution to any problem is to grab a weapon – although your tactics may be cunning. But it isn’t the violence that appeals to you, it’s the attitude. You suffer from intermittent wanderlust, which makes it difficult for you to own a home or hold any permanent job (such as, say, king) for long. This is obviously closely related to the similarly named Odious Personal Habit (p. 29), and you may have both, but that’s externalised and annoying to others, whereas this is personal and dangerous to you.",
+							"base_points": -10,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "93baccdf-89af-46f3-80e9-8d36f64563d1",
+							"type": "trait",
+							"name": "Compulsive Carousing",
+							"reference": "DW58",
+							"userdesc": "You never miss a party and always hit the bars when in town. You like strong booze, loud music, and messy romantic relationships.",
+							"modifiers": [
+								{
+									"id": "8ec8caac-e3f0-43ef-88d1-4e80edcb92ad",
+									"type": "modifier",
+									"name": "Puritanical Setting",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"base_points": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "719115ae-5ce6-4c0d-871f-53f8bc30f4e7",
+							"type": "trait",
+							"name": "Compulsive Gambling",
+							"reference": "DW58",
+							"userdesc": "You can’t resist a bet – any bet!",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "1c8b1bf8-efb2-465b-802b-15d7bb52997b",
+							"type": "trait",
+							"name": "Compulsive Lying",
+							"reference": "DW58",
+							"userdesc": "Even your friends and allies can’t know whether to trust anything you say. Business partners will very soon decide that you’re a liability.",
+							"base_points": -15,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "c1e1e9ee-5456-48d6-81ea-27313d434695",
+							"type": "trait",
+							"name": "Compulsive Risk-Taking",
+							"reference": "DW58",
+							"userdesc": "You’re addicted to excitement. You climb mountains, sail through storms, take up extreme sports, drink in strange dark taverns, plunder tombs, or commit pointless showy crimes – all just for the rush. You may be able to limit yourself to stuff covered by your personal skills, but this compulsion is liable to get you killed eventually.",
+							"base_points": -15,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "69069216-4402-4d1b-abca-1c2bb3610a9b",
+							"type": "trait",
+							"name": "Compulsive Spending",
+							"reference": "DW58",
+							"userdesc": "You like buying stuff! Make a self-control roll whenever you get a chance to purchase something interesting and you have the money. This raises your cost of living and gives you a penalty to your Merchant skill when you’re bargaining for something cool, depending on your self-control number: +10%/-1 for a self-control number of 15, +20%/-2 for 12, +40%/-3 for 9, and +80%/-4 for 6.",
+							"base_points": -5,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "miserliness"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"cr_adj": "major_cost_of_living_increase",
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "41fb200b-63b6-4361-8f00-ca743fb742cf",
+							"type": "trait",
+							"name": "Compulsivee Neatness",
+							"reference": "DW58",
+							"userdesc": "You want everything to be just so, both physical objects (especially your possessions) and numbers and information. You drive friends and colleagues to distraction with all the polishing, tidying, aligning, and double-checking.",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "b41e5bc3-9747-42c6-92b4-980f9d1ea9e8",
+							"type": "trait",
+							"name": "Compulsive Vowing",
+							"reference": "DW58",
+							"userdesc": "You never just decide to do things. You always vow to do them – and you take all your vows seriously, whether they’re ludicrously trivial or insanely difficult.",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "6903a70a-648e-4d87-8ea2-e1801fe004fa",
+							"type": "trait",
+							"name": "Kleptomania",
+							"reference": "DW58",
+							"notes": "You’re compelled to steal – not necessarily things of value, but anything you can get away with. Make a self-control roll whenever you’re presented with a chance to steal, at up to -3 if the item is especially interesting to you (not necessarily valuable, unless you’re poor or have Greed). If you fail, you must try to steal it. You may keep or sell stolen items, but not return or discard them.",
+							"base_points": -15,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "41a4fa9e-c70d-4071-8187-26580ebc2369",
+							"type": "trait",
+							"name": "Trickster",
+							"reference": "DW58",
+							"notes": "You crave the excitement of outwitting dangerous foes. Playing simple tricks on harmless folk is no fun at all – it has to be perilous! Make a self-control roll each day. If you fail, you must try to trick a dangerous subject: a skilled warrior, a terrible monster, a whole group of reasonably competent victims, etc. If you resist, you get a cumulative -1 per day to your self-control roll until you finally fail!",
+							"base_points": -15,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to resist rolls for each day resisted",
+									"amount": -1
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "or worse from people who disapprove of your habits",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -15
+							}
+						}
+					],
+					"name": "Compulsive Behaviour",
+					"userdesc": "You have a habit or a vice that wastes a good deal of your time or money. You must indulge at least once per day, if possible, and do so any time you have the opportunity unless you can make a self-control roll. You must also make a self-control roll to enter a situation where you’ll be unable to indulge for more than a day; if you succeed (or are forced into the situation), you suffer from Bad Temper (p. 64) the whole time, with the same self-control roll as your Compulsive Behaviour. Some people may be amused by your habits, but anyone who disapproves will react to you at -1 or worse.",
+					"calc": {
+						"points": -95
+					}
+				},
+				{
+					"id": "12c05ac7-2b1f-4db4-a820-4feff3620144",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "d77b3e72-59f0-46f0-a3c3-ae58569e646c",
+							"type": "trait",
+							"name": "Disciplines of Faith (Asceticism)",
+							"reference": "DW59",
+							"userdesc": "You lead a life of self-denial and selfdiscipline, often involving isolation in bleak wilderness, and possibly bouts of self-punishment. You cannot have above-average Wealth, or Status beyond that granted by your Religious Rank (if any). Some temples find it safer to suggest this sort of thing to extremely devout followers than to keep them hanging around causing trouble.",
+							"base_points": -15,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "f546f8c7-0995-4119-b48b-3944f2684491",
+							"type": "trait",
+							"name": "Disciplines of Faith (Monasticism)",
+							"reference": "DW59",
+							"userdesc": "You live in a monastery, are completely devoted to religious pursuits, and must spend at least 75% of your time sequestered from the world. You cannot have above-average Wealth, or Status beyond that granted by your Religious Rank (if any).",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "ccc411fb-b4a4-4dc8-a269-584fa006d707",
+							"type": "trait",
+							"name": "Disciplines of Faith (Mysticism)",
+							"reference": "DW59",
+							"userdesc": "You spend most of your time in deep meditation and trance-like contemplation, complete with chanting, consumption of exotic mushrooms, or other trappings. Individuals other than devout coreligionists consider you a bit mad: -2 to reactions.",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "7bb495de-1443-4708-bd38-e615d2c03fdb",
+							"type": "trait",
+							"name": "Disciplines of Faith (Ritualism)",
+							"reference": "DW59",
+							"userdesc": "You stick faithfully to elaborate rituals regarding every aspect of life, from waking to eating to bathing to sex. Each ritual has its proper place, time, words, trappings, and ceremony",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						}
+					],
+					"name": "Disciplines of Faith",
+					"userdesc": "You express your metaphysical beliefs by following a strict set of rules. Few gods actually care whether their followers do this stuff, but some find it a useful way to test and reinforce faith, so such rules end up written into a lot of holy books. Also, some monkish orders based near the Hub – who perhaps serve powers beyond the gods – find that such practises help them achieve useful mystical results.",
+					"calc": {
+						"points": -40
+					}
+				},
+				{
+					"id": "2e9b8aac-cab1-452a-97dc-a0d8605ba632",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "07d3b586-c259-466c-92af-2eefd79475ca",
+							"type": "trait",
+							"name": "Clueless",
+							"reference": "DW61",
+							"userdesc": "You totally miss the point of any wit aimed at you, and are oblivious to attempts at seduction (+4 to resist Sex Appeal). Sophisticated manners are beyond you (giving you -4 to Savoir-Faire), while colloquial expressions escape you. Most people react to you at -2. Unlike No Sense of Humour (p. 65), you may make jokes – lame ones – and you can appreciate slapstick and written humour. However, you rarely “get” verbal humour, and must roll vs. IQ-4 to realise you’re the butt of a joke. And unlike Gullibility (p. 60), you normally realise when someone is trying to take advantage of you, except in social situations; you’re no more susceptible to Fast-Talk than usual, save when someone is trying to convince you that an attractive member of the appropriate sex is interested in you.",
+							"base_points": -10,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "savoir-faire"
+									},
+									"amount": -4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others aware of your clueless nature",
+									"amount": -2
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to resist Sex Appeal",
+									"amount": 4
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "6f7c4bf3-a67a-451e-8a05-1b556c1cccda",
+							"type": "trait",
+							"name": "Confused",
+							"reference": "DW61",
+							"notes": "In a strange place, or when there’s a commotion going on, you must make a self-control roll",
+							"userdesc": "The world seems strange and incomprehensible to you, and you’re slow to pick up on new facts or situations. In particular, you respond poorly to excessive stimulation. Alone in peace and quiet, somewhere familiar, you function normally – but in a strange place, or when there’s a commotion going on, you must make a self-control roll. Failure means you freeze up. The GM should adjust the roll in accordance with the stimuli in the area: resisting confusion from two friends chatting quietly in a familiar room would require an unmodified roll, but a raucous tavern might give -5, and a full-scale riot would give -10! If this disadvantage strikes in combat, you must take the Do Nothing manoeuvre each turn. You aren’t stunned, you can defend yourself normally if you’re directly and physically attacked, and you can even launch a counterattack against that one foe – but you don’t act, only react.",
+							"base_points": -10,
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "b688ef0f-a800-4ad0-9421-c683a83bc778",
+							"type": "trait",
+							"name": "Incurious",
+							"reference": "DW61",
+							"notes": "Make a self-control roll when confronted with something strange. If you fail, you ignore it!",
+							"userdesc": "You hardly ever notice things unrelated to the business at hand. Make a self-control roll when confronted with something strange. Failure means you ignore it! Incurious NPCs react at -1 to novelty.",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "to new things",
+									"amount": -1
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "0a9045ce-9746-4ef3-bb2b-92a43ce84814",
+							"type": "trait",
+							"name": "Hidebound",
+							"reference": "DW61",
+							"userdesc": "You find it difficult to come up with an original thought. You have -2 on any task that requires creativity or invention, including most rolls against Artist skill, all Engineer rolls for new inventions, and all skill rolls made to use the Gadgeteer advantage.",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "on any task that requires creativity or invention, including most rolls against Artist skill, all Engineer rolls for new inventions, and all skill rolls made to use the Gadgeteer advantage",
+									"amount": -2
+								}
+							],
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "61d3f743-1cf0-403a-83b2-77ef909a2474",
+							"type": "trait",
+							"name": "Literal-Minded",
+							"reference": "DW61",
+							"userdesc": "This is mostly found among dwarfs – although they can buy it off with bonus character points, and many other Discworlders seem to have literal-minded tendencies. You use language literally, cannot grasp metaphors, and take rhetorical exaggerations at face value. While people can explain metaphors to you, you find them bizarre. Similes are easier, but they still worry you (“I am NOT attracted to gold like a moth to a flame; I cannot fly . . .”). Ordinary humans find conversations with you annoying, reacting at -1 when the problem becomes evident (-2 for would-be wits and poets), and you may suffer from -1 to -3 to Poetry and most social skills (especially Fast-Talk and Public Speaking) when dealing with a more metaphor-prone audience, at the GM’s option. This is not the same as No Sense of Humour (you just favour rather blunt comedy, full of face-pulling and pratfalls) or Clueless (it doesn’t exclude good manners); but as these things overlap, Literal-Minded is worth fewer points if you take either of these disadvantages",
+							"modifiers": [
+								{
+									"id": "79311f96-7016-4529-adf4-83ef3e87bad8",
+									"type": "modifier",
+									"name": "Clueless and/or No Sense of Humour",
+									"cost": 5,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"base_points": -10,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to -3 to Poetry and most social skills (especially Fast-Talk and Public Speaking) when dealing with a more metaphor-prone audience at the GM's option",
+									"amount": -1
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from human who find conversations with you annoyed (-2 for poets and would-be wits)",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "4f4afa82-ad13-41c4-b1b3-4810bc99860f",
+							"type": "trait",
+							"name": "Low Empathy",
+							"reference": "DW61",
+							"userdesc": "You cannot understand emotions at all. This doesn’t prevent you from having emotions – just from analysing them. You may not take any Empathic Abilities (p. 42), and suffer -3 to Acting, Carousing, Criminology, Detect Lies, Diplomacy, Fast-Talk, Interrogation, Leadership, Merchant, Politics, Psychology, Savoir-Faire, Sex Appeal, and Streetwise.",
+							"base_points": -20,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "oblivious"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "callous"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "empathy"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "acting"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "carousing"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "criminology"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "detect lies"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "diplomacy"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "enthrallment"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fast-talk"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "interrogation"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "leadership"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "merchant"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "politics"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "contains",
+										"qualifier": "psychology"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "contains",
+										"qualifier": "savoir-faire"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "sex appeal"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "sociology"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "streetwise"
+									},
+									"amount": -3
+								}
+							],
+							"calc": {
+								"points": -20
+							}
+						},
+						{
+							"id": "9d187f16-ce01-4463-953b-faa939aba7a2",
+							"type": "trait",
+							"name": "Oblivious",
+							"reference": "DW61",
+							"userdesc": "You understand emotions but not motivations, making you bad at social manipulation. You have -1 to all Influence skills (pp. 74-75) – and also to resist those skills!",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "diplomacy"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fast-talk"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "intimidation"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "savoir-faire"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "sex appeal"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "streetwise"
+									},
+									"amount": -1
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "to resist Influence skills: Diplomacy, Fast-Talk, Intimidation, Savoir-Faire, Sex Appeal, and Streetwise",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "70a46dbb-6bcc-48e3-b640-c025106079d1",
+							"type": "trait",
+							"name": "Totally Oblivious",
+							"reference": "DW61",
+							"userdesc": "This is a worse version of Oblivious, taken to the extreme. Play it for comedy! It has all the same effects and more: You cannot spend points on Acting, Fast-Talk, FortuneTelling, Intimidation, Interrogation, or Politics, and if you try to use any of those skills at default, you’re at -4 (rather than the -1 that applies to only some of them for normal-level Oblivious).",
+							"base_points": -10,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "politics"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "interrogation"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "intimidation"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "fortune-telling"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "fast-talk"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "acting"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fortune-telling"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "interrogation"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "politics"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "acting"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "diplomacy"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fast-talk"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "intimidation"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "savoir-faire"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "sex appeal"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "streetwise"
+									},
+									"amount": -1
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "to resist Influence skills: Diplomacy, Fast-Talk, Intimidation, Savoir-Faire, Sex Appeal, and Streetwise",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						}
+					],
+					"name": "Mental Limitations",
+					"userdesc": "You have a limited approach to the world, which makes you seem stupid or dull (and often annoying). You may actually be fairly bright and even have high IQ. The problem is that you’re often incapable of applying whatever brains you’ve got.\n\nThis category includes several disadvantages, many of which penalise skills. Except as noted, you can still learn those skills – you just aren’t as good at them as other people.",
+					"calc": {
+						"points": -75
+					}
+				},
+				{
+					"id": "5e52a3a7-2861-41cb-8e54-50368936c907",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "fecbc454-d428-48bc-b7f8-d2319399fe05",
+							"type": "trait",
+							"name": "Fanaticism (@Group or ideal@)",
+							"reference": "DW62",
+							"userdesc": "You value a country, organisation, philosophy, or religion (specify this!) above yourself. This doesn’t make you mindless or evil – a wild-eyed priest may be a fanatic, but so is a devoted patriot who dies for his country. Optionally, you may qualify this as Extreme Fanaticism, at no change in point value. Extreme Fanaticism works like regular Fanaticism but means you’ll accept suicide missions unquestioningly, in return for which you get +3 on Will rolls to resist brainwashing, interrogation, and supernatural mind control in any situation where failure would lead you to betray your cause.",
+							"modifiers": [
+								{
+									"id": "478df057-c461-425c-8d04-17a240d0e6e4",
+									"type": "modifier",
+									"name": "Extreme",
+									"disabled": true,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to Will rolls to resist brainwashing, interrogation, and supernatural mind control in any situation where failure would lead you to betray your cause",
+											"amount": 3
+										}
+									]
+								}
+							],
+							"base_points": -15,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "cdb7611d-5128-4ef5-9406-50b486c875cf",
+							"type": "trait",
+							"name": "Obsession",
+							"reference": "DW62",
+							"notes": "@Goal@; Make a self-control roll whenever it would be wise to deviate from your goal. If you fail, you continue to pursue your Obsession, regardless of the consequences.",
+							"userdesc": "Your entire life revolves around a single objective. Make a self-control roll whenever it would be wise to deviate from this path. Failure means you continue to pursue your Obsession, regardless of consequences. Point value depends on the time needed to realise your goal.",
+							"modifiers": [
+								{
+									"id": "aadc441c-1423-4e59-a5ee-9a628b843420",
+									"type": "modifier",
+									"name": "Short term",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "31e5b8b9-f9ba-44e3-8afd-e6b285be3b93",
+									"type": "modifier",
+									"name": "Long term",
+									"cost": -10,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"name": "Obsessive Ideas",
+					"userdesc": "You place something ahead of all other concerns. This can take various forms:",
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "91b48993-78b1-4a2f-9580-b449b61e60e6",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "003f63e4-8ce6-43af-8777-775f8fe55ae0",
+							"type": "trait",
+							"name": "Pacifism: Cannot Harm Innocents",
+							"reference": "DW62",
+							"userdesc": "You may fight, and even start fights, but you may only use deadly force on a foe who’s attempting to do you serious harm. (Capture is not “serious harm”!) You must avoid actions that might harm bystanders.",
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "d4426ac5-a6c7-463e-aa1b-06624ac4b5e7",
+							"type": "trait",
+							"name": "Pacifism: Reluctant Killer",
+							"reference": "DW62",
+							"userdesc": "You have -4 to hit a person (not a monster, machine, etc.) with a deadly attack, and you can’t Aim (p. 175). However, if you can’t see his face, you suffer only -2 and you can Aim. If you kill someone, roll 3d – you’re traumatised and useless (roleplay it!) for that many days. You won’t stop your allies from killing; you might even encourage them.",
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "1c34c132-f591-4cac-bb58-3a3d82d00be5",
+							"type": "trait",
+							"name": "Pacifism: Self-Defense Only",
+							"reference": "DW62",
+							"userdesc": "You may only fight to defend yourself or those in your care, using only as much force as necessary (no preemptive strikes!). You must do your best to discourage others from starting fights, too.",
+							"base_points": -15,
+							"calc": {
+								"points": -15
+							}
+						}
+					],
+					"name": "Pacifism",
+					"userdesc": "You’re opposed to violence. This can take several forms. The first is a fairly normal human lack of “killer instinct”; the others are moral standpoints.",
+					"calc": {
+						"points": -30
+					}
+				},
+				{
+					"id": "88e3ba4d-a05c-43a7-a8bc-392936ca7df0",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "398309e9-e5b3-4173-8c66-bd4d3695de3a",
+							"type": "trait",
+							"name": "Acrophobia (Heights)",
+							"reference": "DW62",
+							"userdesc": "You’ll only willingly go more than 15’ above the ground in a large, solid building – and then you’ll stay well back from the windows. If there’s some chance of an actual fall, self-control rolls are at -5.",
+							"base_points": -10,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "81232a3e-14e7-4921-b6ff-f85a59ec357a",
+							"type": "trait",
+							"name": "Agoraphobia (Open Spaces)",
+							"reference": "DW63",
+							"userdesc": "You’re uncomfortable when you’re outdoors, and frightened if there are no walls within 50’. This isn’t actually common among old-fashioned dwarfs, but it isn’t unknown.",
+							"base_points": -10,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "1d3f4d4f-5a52-47fa-8ac6-a6490638dd8a",
+							"type": "trait",
+							"name": "Claustrophobia (Enclosed Spaces)",
+							"reference": "DW62",
+							"notes": "You are uncomfortable any time you can’t see the sky – or at least a very high ceiling. In a small room or vehicle, you feel the walls closing in on you... You need air! This is a dangerous fear for someone who plans to go underground.",
+							"base_points": -15,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "e6b4f38a-4c37-4cca-8821-855f9a3a52bc",
+							"type": "trait",
+							"name": "Demophobia (Crowds)",
+							"reference": "DW62",
+							"userdesc": "Any group of a dozen people or more. Your self-control roll may be penalised for much larger groups",
+							"base_points": -15,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "1a532dd6-cd26-498a-aefd-02353425e7a6",
+							"type": "trait",
+							"name": "Heliophobia (Sun)",
+							"reference": "DW63",
+							"userdesc": "The sun is another problem more associated with old-school monsters than sane humans. If you think that the terrible yellow eye is out to burn you, you’re unlikely to go out in daytime, even on deeply overcast days; who knows when a gap in the clouds might allow It to get you?",
+							"base_points": -15,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "fe7f5c51-a988-482f-a8bf-25391b682a78",
+							"type": "trait",
+							"name": "Octophobia (Number 8)",
+							"reference": "DW63",
+							"userdesc": "Your self-control roll is at -5 if obvious supernatural powers are involved!",
+							"base_points": -5,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "c067ad53-54f1-4010-8699-849ec4d5a891",
+							"type": "trait",
+							"name": "Pyrophobia (Fire)",
+							"reference": "DW62",
+							"userdesc": "This comes in two varieties. Minor Pyrophobia is about uncontrolled flames – you’re fine around enclosed lamps (so long as you don’t have to think about what’s inside them), cigarettes (still, you don’t smoke), or even a fire in a hearth (though you have nightmares about the place burning down). But if someone waves a lit torch in your face, or you encounter a forest or a building on fire, or a wizard hurls a fireball at you, you flee or cower. Major Pyrophobia means that you cannot deal with any fire, not even a lit cigarette within five yards, which means that you won’t be spending much time with sane humans after dark or in cold regions.",
+							"modifiers": [
+								{
+									"id": "b34d280a-ccb7-40f5-97a7-e26662a87cc6",
+									"type": "modifier",
+									"name": "Minor",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "0f9d6373-a444-4ebf-8924-740796be81c4",
+									"type": "modifier",
+									"name": "Mojor",
+									"cost": -10,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "4fb538f1-d5d2-49ea-9d6b-73aa766945be",
+							"type": "trait",
+							"name": "Scotophobia (Darkness)",
+							"reference": "DW62",
+							"notes": "A common fear, but crippling. You should avoid being underground if possible; if something happens to your flashlight or torch, you might well lose your mind before you can relight it.",
+							"userdesc": "Nothing to do with bagpipes",
+							"base_points": -15,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "eec187bc-c12b-4aa2-9e96-fa9905f525e1",
+							"type": "trait",
+							"name": "Squeamish",
+							"reference": "DW63",
+							"userdesc": "You have a strong dislike of “yucky stuff”: little bugs and crawly things, blood and dead bodies, slime, etc. You don’t suffer from simple fears of insects, reptiles, dirt, or the dead, because huge bugs or reptiles, ordinary dirt, and ghosts don’t especially bother you; it’s nasty creepy things, filth, and bits of grue that make you jump back.",
+							"base_points": -10,
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "6689ad83-4248-458b-897f-2dd45d0323ac",
+							"type": "trait",
+							"name": "Teratophobia (Monsters)",
+							"reference": "DW63",
+							"userdesc": "Trolls, gargoyles, etc., don’t count as “monsters” on the Disc; they’re widely known to be talking, (slow-)thinking beings. However, adventurers will meet plenty of actual monsters – and from the viewpoint of typical citizens of Ankh-Morpork, this category might include huge “mundane” animals such as rhinoceroses and large squid.",
+							"base_points": -15,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "605f7d35-5323-4112-ad12-413527f76933",
+							"type": "trait",
+							"name": "Xenophobia (Strange and Unknown Things)",
+							"reference": "DW63",
+							"userdesc": "You’re upset by strange circumstances, and especially by strange people. Make a self-control roll when you’re surrounded by people of a different nationality, at -3 if they’re a different species to you. If you fail, you may well attack strangers in your panic. This isn’t usually suitable for adventurers, but some Agateans and deep-dwelling dwarfs are sufferers.",
+							"base_points": -15,
+							"cr": 12,
+							"cr_adj": "action_penalty",
+							"calc": {
+								"points": -15
+							}
+						}
+					],
+					"name": "Phobias",
+					"userdesc": "A “Phobia” is fear of an item, creature, or circumstance; the more common the object of your fear, the more points you get.You may attempt a self-control roll to master your Phobia temporarily. Failure means you cringe, flee, panic, or otherwise lose control. Pick something amusing; what’s important is that you’re useless. Even if you succeed, the fear persists – you suffer -2 to all IQ, DX, and skill rolls while the cause of your fear is present, and you must roll again every 10 minutes to see if the fear overcomes you.\n\nEven the threat of the feared object requires a selfcontrol roll at +4. If your enemies actually inflict the feared object on y",
+					"calc": {
+						"points": -125
+					}
+				},
+				{
+					"id": "dbac45cb-8079-45fa-8b2a-3d214ab817db",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "ac73e618-4134-43f7-91c4-1e0eaf06e739",
+							"type": "trait",
+							"name": "Bad Grip",
+							"reference": "DW63",
+							"userdesc": "Each level of this trait (maximum three levels) gives -2 to skill or DX rolls for melee weapons, climbing, catching things, and anything else the GM decides is appropriate.",
+							"levels": 1,
+							"points_per_level": -5,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "no fine manipulators"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to tasks that require a firm grip (max 3 levels)",
+									"amount": -2,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "fae78704-cd46-4e80-923a-452f037a9818",
+							"type": "trait_container",
+							"children": [
+								{
+									"id": "d9019265-020e-474f-98d1-b3f12c47ef91",
+									"type": "trait",
+									"name": "Bad Sight (Nearsighted)",
+									"reference": "DW63",
+									"notes": "Double actual distance to the target when calculating the range modifier for ranged attacks",
+									"userdesc": "If Nearsighted, you cannot read small writing more than a foot away, or shop signs, etc., at more than about 10 yards; have -6 to Vision rolls to spot items more than a yard away; are at -2 to skill when making a melee attack; and must double the actual distance to your target when calculating the range modifier for a ranged attack.",
+									"modifiers": [
+										{
+											"id": "bcf5ee4d-8f70-41e5-81ee-9f4a2956f9c3",
+											"type": "modifier",
+											"name": "Mitigator",
+											"notes": "Glasses",
+											"cost": -60,
+											"disabled": true
+										}
+									],
+									"base_points": -25,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to Vision rolls to spot items more than 1 yd away",
+											"amount": -6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to all melee attacks",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -25
+									}
+								},
+								{
+									"id": "549b816b-9dc2-4103-91cc-40920aaf7f2c",
+									"type": "trait",
+									"name": "Bad Sight (Farsighted)",
+									"reference": "DW63",
+									"userdesc": "If Farsighted, you cannot read text except with great difficulty and triple normal time; are at -6 to Vision rolls to spot items within one yard; and have -3 to DX on any close manual task, including close combat. Either can sometimes be corrected with eyeglasses, which act as a mitigator (p. 53).",
+									"modifiers": [
+										{
+											"id": "5f9a7d75-de73-40c4-bbc9-f8f6a058a9ba",
+											"type": "modifier",
+											"name": "Mitigator",
+											"notes": "Glasses",
+											"cost": -60,
+											"disabled": true
+										}
+									],
+									"base_points": -25,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to Vision rolls to spot items within 1 yd",
+											"amount": -6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to DX for any close manual task, including close combat",
+											"amount": -3
+										}
+									],
+									"calc": {
+										"points": -25
+									}
+								}
+							],
+							"name": "Bad Sight",
+							"userdesc": "You have poor vision, which comes in two varieties.",
+							"calc": {
+								"points": -50
+							}
+						},
+						{
+							"id": "24e2a6d6-1946-48b0-80e7-b2255f7a4d1f",
+							"type": "trait",
+							"name": "Hard of Hearing",
+							"reference": "DW63",
+							"userdesc": "You’re at -4 on any Hearing roll, and on any skill roll where it’s important that you understand someone else.",
+							"base_points": -10,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "hearing",
+									"amount": -4
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to any skill roll where it is important that you understand someone speaking",
+									"amount": -4
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "c32d30a8-f6ca-418f-98a1-4f32f4e49df1",
+							"type": "trait",
+							"name": "Hunchback",
+							"reference": "DW63",
+							"userdesc": "You have a spinal deformity that forces you into a twisted or hunched position, resulting in a noticeable hump or lump on one or both shoulders. You’re about 10% shorter than a normal being of your ST. Normal clothing and armour will fit badly, giving you -1 to DX; to avoid this, you must pay an extra 10% for specially made gear. Most people find you disturbing and react at -1. This penalty is cumulative with regular Appearance modifiers, and you may have no better than Average looks. Your appearance is also distinctive, giving you -3 to Disguise and Shadowing skills, and +3 to others’ attempts to identify or follow you.",
+							"modifiers": [
+								{
+									"id": "d47eeba8-96e5-4fcd-8455-1c125ca554a5",
+									"type": "modifier",
+									"name": "DX penalty if not wearing custom-made clothing and armor",
+									"reference": "B139",
+									"notes": "Clothing and armor costs 10% more than usual",
+									"disabled": true,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "dx",
+											"amount": -1
+										}
+									]
+								}
+							],
+							"base_points": -10,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Appearance (Beautiful)"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Appearance (Handsome)"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Appearance (Very Beautiful)"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Appearance (Very Handsome)"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Appearance (Attractive)"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "disguise"
+									},
+									"amount": -3
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "shadowing"
+									},
+									"amount": -3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to others attempting to identify or follow you",
+									"amount": 3
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "efd2bae3-aa0a-498d-8afe-a1de7d5fbc70",
+							"type": "trait",
+							"name": "Lame ",
+							"reference": "DW63",
+							"notes": "You must reduce your Basic Move to half your Basic Speed (round down)",
+							"userdesc": "You’re at -3 to use any skill that requires use of your legs, including all melee weapon and unarmed combat skills (but not ranged combat skills). You must reduce your Basic Move to half your Basic Speed (round down) or less, but you get the usual -5 points/level for this (see Basic Move, p. 28).",
+							"base_points": -10,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to use any skill that requires the use of your legs, including all Melee Weapon and unarmed combat skills (but not ranged combat skills)",
+									"amount": -3
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "2bbfbdf3-47e5-40fd-ae7b-7500bccc0af4",
+							"type": "trait",
+							"name": "Motion Sickness",
+							"reference": "DW63",
+							"userdesc": "You’re miserable whenever you’re in a moving vehicle such as a stagecoach or ship. You may never learn any vehicle-operation skill. You must roll vs. HT as soon as you’re aboard a moving vehicle. Failure means you vomit and are at -5 on all DX, IQ, and skill rolls for the rest of the journey. On a success, you’re merely miserably queasy and at -2 on DX, IQ, and skill rolls. Roll daily on long journeys.",
+							"base_points": -10,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "submariner"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "submarine"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "spacer"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "shiphandling"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "seamanship"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "contains",
+											"qualifier": "crewman"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "boating"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "airshipman"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "contains",
+											"qualifier": "driving"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "contains",
+											"qualifier": "piloting"
+										}
+									}
+								]
+							},
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "f45b76b3-1891-4fc5-bc50-e4833c016e9a",
+							"type": "trait",
+							"name": "No Legs",
+							"reference": "DW63",
+							"userdesc": "Either you’ve lost both legs or they’re completely paralysed. You’re at -6 to use any skill that requires use of your legs, and you cannot stand, kick, or walk at all. You must reduce your Basic Move to 0, but you get full points for this. A wheelchair will give you ground Move equal to 1/4 your ST (round down), but has many problems with manoeuvring and doorways.",
+							"base_points": -30,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to use any skill that requires the use of your legs, including all Melee Weapon and unarmed combat skills (but not ranged combat skills)",
+									"amount": -6
+								}
+							],
+							"calc": {
+								"points": -30
+							}
+						},
+						{
+							"id": "47734c09-35cd-4d78-a595-3070d8993b42",
+							"type": "trait",
+							"name": "One Arm",
+							"reference": "DW64",
+							"userdesc": "You’ve lost one arm. You get -4 on tasks that are possible with one arm but that are usually executed with two (e.g., most Climbing and Wrestling rolls). You have no penalty on tasks that require only one arm. In all cases, the GM’s ruling is final.",
+							"base_points": -20,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "on tasks that are possible with one arm but that are usually executed with two",
+									"amount": -4
+								}
+							],
+							"calc": {
+								"points": -20
+							}
+						},
+						{
+							"id": "db5f264e-e176-4ce9-a034-ba9ceb2ae9d1",
+							"type": "trait",
+							"name": "One Eye",
+							"reference": "DW64",
+							"userdesc": "You have only one eye. You suffer -1 to DX in melee combat (that is, -1 to melee weapon, Shield, and unarmed combat skills) and on any task involving hand-eye coordination. This worsens to -3 on ranged attacks, unless you Aim (p. 175) first, and on rolls to operate vehicles at high speeds in tricky situations.",
+							"base_points": -15,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "No Depth Perception"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to DX in combat and on any task involving hand-eye coordination",
+									"amount": -1
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "on ranged attacks (unless you Aim first) and on rolls to operate any vehicle faster than a horse and buggy",
+									"amount": -3
+								}
+							],
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "89084886-3a45-46cf-a496-d79240de9b9a",
+							"type": "trait",
+							"name": "One Hand",
+							"reference": "DW64",
+							"userdesc": "You have only one hand. For the most part, use the rules for One Arm. The difference is that you may make unarmed parries with a handless arm, and possibly strap something to it (e.g., a shield). You can also have a hook or claw fitted, which counts as an undroppable large knife in combat and gives +1 to Intimidation skill if waved at your foes. ",
+							"base_points": -15,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "on tasks that are possible with one arm but that are usually executed with two",
+									"amount": -4
+								}
+							],
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "dd761b62-ea57-4b28-bbc4-aa15cead80b5",
+							"type": "trait",
+							"name": "One Leg",
+							"reference": "DW64",
+							"notes": "Using crutches or a peg leg, you can stand up and walk slowly. You must reduce Basic Move to 2.",
+							"userdesc": "You’ve lost one leg, giving you -6 to any skill that requires use of your legs. Using crutches or a peg leg, you can stand up and walk slowly. You must reduce your Basic Move to 2 or less, but you get full points for this. You can still kick, but between the standard -2 for a kick and -6 for this disadvantage, you do so at -8! Without your crutches or peg leg, you cannot stand, walk, or kick at all.",
+							"base_points": -20,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to use any skill that requires the use of your legs, including all Melee Weapon and unarmed combat skills (but not ranged combat skills)",
+									"amount": -6
+								}
+							],
+							"calc": {
+								"points": -20
+							}
+						}
+					],
+					"name": "Physical Problems",
+					"userdesc": "You have a serious physical disability or permanent injury. Unless noted otherwise, assume that where the problem is obvious, any effects on others’ reactions are factored into your Appearance rating.",
+					"calc": {
+						"points": -195
+					}
+				},
+				{
+					"id": "d9856937-db3c-4972-9101-5d848604eb7c",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "3b829d7f-de7e-4983-81bc-1621be583192",
+							"type": "trait",
+							"name": "Bad Temper",
+							"reference": "DW64",
+							"userdesc": "Roll in any stressful situation. Failure means you must insult, attack, or otherwise act against the cause of the stress.",
+							"base_points": -10,
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "d02c8047-8145-43f4-b550-0f2e25713499",
+							"type": "trait",
+							"name": "Bloodlust",
+							"reference": "DW64",
+							"notes": "You must make a self-control roll whenever you need to accept a surrender, evade a sentry, take a prisoner, etc.",
+							"userdesc": "An enemy is always an enemy, and should die! Roll whenever you must accept a surrender, evade a sentry, take a prisoner, etc. Failure means you attempt to kill your foe instead. (You don’t get carried away in bar-room brawls though, unless knives or swords come out.) This isn’t especially heroic, but it may pass as “excess enthusiasm” in, say, a wartime army. Among watchmen or Guild thieves, though – or even Guild Assassins – it’ll soon get you thrown out, or dead.",
+							"base_points": -10,
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "a9dfcc99-1a9d-4c0c-bbdc-543c91cde7fe",
+							"type": "trait",
+							"name": "Bully",
+							"reference": "DW64",
+							"userdesc": "Roll whenever you have a chance to degrade another person – physically, mentally, or socially – to make yourself look “better.” Failure means you do that . . . and usually make yourself look worse.",
+							"base_points": -10,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "10929f1f-42b2-43ba-bc99-211778fdfe82",
+							"type": "trait",
+							"name": "Cowardice",
+							"reference": "DW64",
+							"notes": "Make a self-control roll any time you are called on to risk physical danger. Roll at -5 if you must risk death.",
+							"userdesc": "Roll whenever you’re called on to risk physical danger (at -5 if you face death). Failure means you refuse to endanger yourself (unless threatened with greater danger), and perhaps even flee! You also suffer a penalty to Fright Checks whenever physical danger is involved: -1 for a self-control number of 15, -2 for 12, -3 for 9, and -4 for 6.",
+							"base_points": -10,
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "f0886898-f420-4aea-97a1-5b0d910cc650",
+							"type": "trait",
+							"name": "Curious",
+							"reference": "DW64",
+							"notes": "Make a self-control roll when presented with an interesting item or situation",
+							"userdesc": "Roll whenever you’re presented with an interesting item or situation. Failure means you try the interesting-looking mushrooms, pull the big creaky lever, ask impertinent questions, etc.",
+							"base_points": -5,
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "87f04c99-51c3-4bf5-84fe-03057803d98a",
+							"type": "trait",
+							"name": "Gluttony",
+							"reference": "DW64",
+							"notes": "Make a self-control roll when presented with a tempting morsel or good wine that, for some reason, you should resist. If you fail, you partake – regardless of the consequences.",
+							"userdesc": "Roll whenever food or drink is present, or any time you have the chance to acquire provisions. Failure means you partake when you shouldn’t, burden yourself with extra rations, etc.",
+							"base_points": -5,
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "eec4128a-a32a-4981-a048-a66151dd7a6b",
+							"type": "trait",
+							"name": "Greed",
+							"reference": "DW64",
+							"notes": "Make a self-control roll any time riches are offered – as payment for fair work, gains from adventure, spoils of crime, or just bait. If you fail, you do whatever it takes to get the payoff.",
+							"userdesc": "Roll whenever wealth is offered (at -5 for large sums). Failure means you do whatever it takes to get the payoff – even if that means crime. Dwarfish Greed is a minor variant of Greed with the same value; it involves a peculiar obsession with gold, and to a lesser extent silver, so that an offer of coins or nuggets gets the same response as offers of much higher value in other forms. Sufferers from Dwarfish Greed are also quite unwilling to spend or let go of gold, although they may not be especially miserly in other ways (unless they also have Miserliness). Dwarfs don’t react badly to Dwarfish Greed, considering it natural.",
+							"base_points": -15,
+							"cr": 12,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "d438377e-448f-48cf-9eb4-707c84de2af3",
+							"type": "trait",
+							"name": "Impulsiveness",
+							"reference": "DW64",
+							"notes": "Make a self-control roll whenever it would be wise to wait and ponder. If you fail, you must act",
+							"userdesc": "Roll whenever debate and planning threaten to hold up action, and any time you should stop to think about what you’re doing. Failure means you act immediately!",
+							"base_points": -10,
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "afbc5f0c-f160-4970-af9f-a0aa4c1440ce",
+							"type": "trait",
+							"name": "Lecherousness",
+							"reference": "DW64",
+							"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+							"userdesc": "Roll whenever you have contact with an appealing member of the sex you find attractive (-5 if this person is Handsome/Beautiful, -10 if Very Handsome/Very Beautiful). Failure means you make a pass.",
+							"base_points": -15,
+							"cr": 12,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "1375053d-7e07-4eb8-a909-2b0165cefcc3",
+							"type": "trait",
+							"name": "Sadism",
+							"reference": "DW64",
+							"notes": "Make a self-control roll whenever you have an opportunity to indulge your desires and know you shouldn’t (e.g., because the prisoner is one who should be released unharmed). If you fail, you cannot restrain yourself.",
+							"userdesc": "Roll whenever you have an opportunity to engage in physical or mental cruelty for its own sake. Failure means you behave in an evil way. The GM may wish to disallow this trait for PCs, who are normally supposed to be the heroes.",
+							"base_points": -15,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those who become aware of your Sadism unless they are from a culture that holds life in little esteem",
+									"amount": -3
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -15
+							}
+						}
+					],
+					"name": "Poor Impulse Control",
+					"userdesc": "You have incomplete control over some unfortunate psychological tendency. When exposed to an appropriate stimulus, you must make a self-control roll or do something unwise. The GM may penalise this roll for unusually strong temptations. Even if you don’t give in, you should roleplay your struggle! Those who witness your behaviour will often react poorly: -1 to reaction rolls per full -5 points of disadvantage value.",
+					"calc": {
+						"points": -105
+					}
+				},
+				{
+					"id": "8669b37d-448b-4822-b6e7-35b5bb862960",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "960380a9-4f17-49f5-98ce-acc02e4167d6",
+							"type": "trait_container",
+							"children": [
+								{
+									"id": "c1cb94f7-5175-41d9-88e4-709301b5aca7",
+									"type": "trait",
+									"name": "@Mental Quirk@",
+									"reference": "DW66",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "bdf7af96-4dd6-4617-b237-dbce2012f987",
+									"type": "trait",
+									"name": "Attentive",
+									"reference": "DW66",
+									"userdesc": "You stick to one task until it’s done. You get +1 when working on lengthy tasks – but -3 to notice any important interruption!",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "b098930a-27aa-403b-af66-b13ebac5ee01",
+									"type": "trait",
+									"name": "Automondimentor",
+									"reference": "DW66",
+									"userdesc": "Whenever you sit down to eat, you immediately add salt, pepper, and probably any available sauces to your food, without even tasting it first. This makes you easier to drug or poison if you aren’t careful, and it causes serious chefs and cooks to react to you at -3 or worse, possibly with violence.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "or worse from chef and cooks",
+											"amount": -3
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "65c19b19-d763-4ec3-963c-3fa88ef63ab8",
+									"type": "trait",
+									"name": "Broad-Minded",
+									"reference": "DW66",
+									"userdesc": "You get along well with other races and species, and strange looks rarely bother you.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "a36d6ce5-233f-47df-828f-6c0d47024511",
+									"type": "trait",
+									"name": "Careful",
+									"reference": "DW67",
+									"userdesc": "This is quirk-level Cowardice (p. 64) – you’re naturally cautious, always on the lookout for danger. You spend extra time and money on preparations before venturing into danger.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "58ca718a-95a1-4353-acbd-353dd7f93d05",
+									"type": "trait",
+									"name": "Chauvinistic",
+									"reference": "DW67",
+									"userdesc": "This extremely low-level Intolerance (p. 60) means you’re always aware of differences in sex, skin colour, etc. even if you don’t actually react poorly to others. Thin-skinned individuals might occasionally react to you at -1.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from individuals sensitive to criticism or insults that you interact with",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "7f4dbdc7-20f0-49ac-8be5-aca10af94ee6",
+									"type": "trait",
+									"name": "Code of Honour",
+									"reference": "DW67",
+									"notes": "@Subject@",
+									"userdesc": "You may take a minor Code of Honour (pp. 56-57) as a quirk. For instance, you might insist on exhibiting “gentlemanly” behaviour toward all women, or spurning “chauvinistic” behaviour.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "29aa33c6-76d3-4a0e-b1e7-55fbd4492a7a",
+									"type": "trait",
+									"name": "Congenial",
+									"reference": "DW67",
+									"userdesc": "This milder version of Chummy (p. 56) means you like company and work well with others. You always choose group action over individual action.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "d7a1623c-3c7a-4007-9fe8-ad89aa32e318",
+									"type": "trait",
+									"name": "Delusions",
+									"reference": "DW67",
+									"notes": "@Subject@",
+									"userdesc": "A completely trivial Delusion (p. 59) makes a good quirk. This doesn’t affect your everyday behaviour, and casual acquaintances are unlikely to notice it – but you truly believe it! Examples: “The world is a sphere.” “The Temple of Offler controls all the restaurants in Ankh-Morpork.” “Socks cause diseases of the feet.”",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "51ada820-7423-46d9-8b2d-052c02333be9",
+									"type": "trait",
+									"name": "Dislikes @Item@",
+									"reference": "DW67",
+									"userdesc": "You can have any Phobia (pp. 62-63) at the level of a mere “dislike.” If you dislike something, you must avoid it whenever possible, but it doesn’t actually harm you as a Phobia would. Dislikes don’t have to be watered-down Phobias. There’s a whole Disc full of things to dislike: carrots, cats, fancy travelling cloaks, violence, the clacks, taxes . . .",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "3dc69f7c-dc18-4f83-9252-12a92e3c03ec",
+									"type": "trait",
+									"name": "Distractible",
+									"reference": "DW67",
+									"userdesc": "This is quirk-level Short Attention Span (p. 65). You are easily distracted and don’t do well on long-term projects. You’re at -1 when rolling to accomplish long tasks.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "on any long task",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "deef12b2-0622-48f2-b169-311e4e0d635b",
+									"type": "trait",
+									"name": "Dreamer",
+									"reference": "DW67",
+									"userdesc": "You have -1 on any long task, because you tend to spend time thinking of better ways to do it, rather than working.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "on any long task",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "170f4091-fcbe-4a00-82ae-fb19ae96ea7d",
+									"type": "trait",
+									"name": "Dull",
+									"reference": "DW67",
+									"userdesc": "While not quite Hidebound (p. 61), you tend to stick with tried-and-true methods.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "0c523e6b-0af6-4173-b608-6c78a8939b6f",
+									"type": "trait",
+									"name": "Former Alcoholic",
+									"reference": "DW67",
+									"userdesc": "You used to have Alcoholism (pp. 54-55), but have shed the addiction so successfully that you don’t have to roll to resist booze if it’s offered – you really have learned to handle things. However, being teetotal is sometimes socially inconvenient, and you may get slightly twitchy or terse in the presence of drink.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "c081b221-3090-43cd-b4c2-9ced690523b6",
+									"type": "trait",
+									"name": "Giggles a Lot",
+									"reference": "DW67",
+									"userdesc": "This is a trifling Odious Personal Habit (p. 29) which is slightly annoying for other people, especially in high-stress moments, and may get -1 or worse reactions from very serious individuals.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "or worse from serious individuals",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "550f7389-a9cf-4e92-a5ae-7709fb7815dc",
+									"type": "trait",
+									"name": "Habits or Expressions",
+									"reference": "DW67",
+									"notes": "@Habit or Expression@",
+									"userdesc": "Saying “By Mighty Zephyrus!” or “Bless my cloak-pin” constantly, say, or carrying a silver coin that you habitually flip into the air.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "5dff747a-8a93-4a41-9086-45c82eebfdfe",
+									"type": "trait",
+									"name": "Humble",
+									"reference": "DW67",
+									"userdesc": "A weak form of Selfless (p. 66) – you tend to put the concerns of others, or of the group, before your own.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "b00b6ea5-1dad-455f-a840-e9124bd3e253",
+									"type": "trait",
+									"name": "Imaginative",
+									"reference": "DW67",
+									"userdesc": "You’re a font of ideas and are more than willing to share them with others. They may or may not be good ideas.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "f865d30e-9bc7-4bcb-9ad4-bf65cd6980e4",
+									"type": "trait",
+									"name": "Likes @Item@",
+									"reference": "DW67",
+									"userdesc": "You like something, seeking it out whenever possible. Gadgets, kittens, shiny knives, fine art . . . whatever. This isn’t a compulsion – just a preference.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "5332bbbb-ceac-4856-9bae-8e67a026dad1",
+									"type": "trait",
+									"name": "Nosy",
+									"reference": "DW67",
+									"userdesc": "This lesser version of Curious (p. 64) means you’re always poking your nose into corners and everyone else’s business.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "dab22e58-be5a-451a-a54d-05154d2a127a",
+									"type": "trait",
+									"name": "Obsession",
+									"reference": "DW67",
+									"notes": "@Subject@",
+									"userdesc": "An almost-rational, not especially unusual Obsession (p. 62) can be a quirk. For instance, you may hope to get just enough money to buy a farm (or a ship, or a castle) of your own.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "cd40aa96-e3f3-4b0b-bbe6-47e465744039",
+									"type": "trait",
+									"name": "Personality Change",
+									"reference": "DW67",
+									"notes": "@Circumstance@",
+									"userdesc": "You suffer from a full-blown mental disadvantage, but only in circumstances that are normally under your control – Bully when you drink too much, say, or Pyromania when you work with fire magic.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "f77cbfa7-9d8a-42f1-8102-9997259a4004",
+									"type": "trait",
+									"name": "Proud",
+									"reference": "DW68",
+									"userdesc": "This is quirk-level Selfish (p. 65). Individual success, wealth, or social standing concerns you greatly. Proud NPCs react at -1 to orders, insults, or social slights.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "to orders, insults, or social slights",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "0b130394-53a1-4d52-bc83-a18ad935ed1c",
+									"type": "trait",
+									"name": "Responsive",
+									"reference": "DW68",
+									"userdesc": "A mild case of Charitable (p. 65) – all other things being equal, you’re inclined to help others.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "0339e9bb-d8c5-45fb-b384-dc2ec933ef20",
+									"type": "trait",
+									"name": "Staid",
+									"reference": "DW68",
+									"userdesc": "With this very low level of Incurious (p. 61), you’re likely to ignore matters that don’t immediately affect you.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "74dc30d3-0909-47d3-a90c-e3af32189743",
+									"type": "trait",
+									"name": "Terrifying Singer",
+									"reference": "DW68",
+									"userdesc": "You like singing, despite a complete lack of ability, and your singing voice is loud and penetrating enough to wake the neighbourhood and frighten animals.",
+									"base_points": -1,
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is"
+												},
+												"level": {
+													"compare": "at_least"
+												}
+											},
+											{
+												"type": "skill_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Singing"
+												},
+												"level": {
+													"compare": "at_least"
+												}
+											}
+										]
+									},
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "e2500a8c-76e1-4341-985f-8a7445a89da9",
+									"type": "trait",
+									"name": "Uncongenial",
+									"reference": "DW68",
+									"userdesc": "You prefer to be alone, and you always choose individual action over group action if you have a choice.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "d442faf0-432f-4751-ac0b-067d718137e4",
+									"type": "trait",
+									"name": "Vow",
+									"reference": "DW68",
+									"notes": "@Subject@",
+									"userdesc": "A trivial Vow (p. 66) – e.g., never drink alcohol, treat all elders with courtesy, or pay 10% of your income to your temple – is a quirk.",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"name": "Mental",
+							"userdesc": "These are minor personality traits. You must roleplay them. If you choose “Dislikes heights,” but blithely climb trees and cliffs whenever you need to, the GM will penalise you for bad roleplaying.\n\nTo qualify as a mental quirk, a personality trait must meet one of two criteria:\n• It requires a specific action, behaviour, or choice on your part on occasion.\n• It gives you a small penalty very occasionally, or to a narrow set of actions.\n\nBe creative – the quirks below are merely examples!",
+							"calc": {
+								"points": -28
+							}
+						},
+						{
+							"id": "63b207e0-fbff-4c03-a1ff-20c3d822b276",
+							"type": "trait_container",
+							"children": [
+								{
+									"id": "4127ba69-de4c-4eab-8a5a-809531514569",
+									"type": "trait",
+									"name": "@Physical Quirk@",
+									"reference": "DW68",
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "7e27ed04-1ce2-4fba-b1d3-b6c671c2b415",
+									"type": "trait",
+									"name": "Alcohol Intolerance",
+									"reference": "DW68",
+									"userdesc": "Alcohol “goes right to your head.” You become intoxicated much more quickly than normal. You get -2 on any HT roll related to drinking.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "on all HT rolls related to drinking",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "cbd24619-6618-4156-a9fc-e5741b3d4a64",
+									"type": "trait",
+									"name": "Bowlegged",
+									"reference": "DW68",
+									"userdesc": "You’re bowlegged. This doesn’t normally affect Move, but you have -1 to Jumping skill. This quirk may elicit a -1 reaction from those who think it looks funny.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Jumping"
+											},
+											"amount": -1
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from those who think Bowlegged looks funny",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "9861f0cb-ab21-486f-9d83-2a6eed47c778",
+									"type": "trait",
+									"name": "Distinctive Features",
+									"reference": "DW68",
+									"userdesc": "You have a physical feature – e.g., “Brilliant blue hair” – that makes you stand out in a crowd. This gives -1 to your Disguise and Shadowing skills, and +1 to others’ attempts to identify or follow you. Compare Unnatural Features (p. 30) and Supernatural Features (p. 97).",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -1
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to others’ attempts to identify or follow you",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "62ce883c-7a59-4db6-b67c-79d3c8d47679",
+									"type": "trait",
+									"name": "Horrible Hangovers",
+									"reference": "DW68",
+									"userdesc": "You suffer an additional -3 to any penalties the GM assesses for excessive drinking the previous evening, and you add three hours to hangover duration.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "added to any penalties assessed for excessive drinking the previous evening and add 3 hours to hangover duration",
+											"amount": -3
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "a2cdb653-d1b0-4a19-b8f0-39f8746baeba",
+									"type": "trait",
+									"name": "Minor Handicap (@Body Part@)",
+									"reference": "DW68",
+									"userdesc": "You may take most mundane physical disadvantages at quirk level. For instance, you could use a watered-down version of Lame for a “creaky knee.” Difficulties rarely crop up, but are inconvenient when they do. The GM may give you -1 to attribute, skill, or reaction rolls, as appropriate, in situations where the handicap would logically interfere.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to attribute, skill, or reaction rolls, as appropriate, in situations where Minor Handicap (@Body Part@) would logically interfere",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "8694e081-0e01-4f41-a499-9c92614fb292",
+									"type": "trait",
+									"name": "Nervous Stomach",
+									"reference": "DW68",
+									"userdesc": "You have -3 to HT rolls to avoid illness (typically in the form of attribute penalties or vomiting) brought on by rich or spicy food, strong drink, etc.",
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to HT rolls to avoid illness brought on by rich or spicy food, strong drink, etc.",
+											"amount": -3
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "898f94fe-d06d-455b-bda3-c6d53b822842",
+									"type": "trait",
+									"name": "No Staff",
+									"reference": "DW68",
+									"userdesc": "You haven’t yet acquired a wizard’s staff, so you lack the extra power that grants. You must buy off this quirk if you receive a staff (upon graduation, from a mentor, etc.).",
+									"base_points": -1,
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "skill_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magic"
+												},
+												"level": {
+													"compare": "at_least"
+												},
+												"specialization": {
+													"compare": "is",
+													"qualifier": "Wizard"
+												}
+											}
+										]
+									},
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"name": "Physical/Social",
+							"userdesc": "These are physical or practical disadvantages that are only mildly or rarely limiting. They don’t require roleplaying, but give specific, minor penalties in play. Again, these examples only begin to describe what’s possible.",
+							"calc": {
+								"points": -8
+							}
+						}
+					],
+					"name": "Quirks",
+					"userdesc": "A “quirk” is a minor personal trait. Neither an advantage nor necessarily a disadvantage, it’s just something specific about you. For instance, Compulsive Carousing is a disadvantage; you’re forever getting sidetracked by offers of a good time, and you annoy quiet companions by trying to involve them. But if you merely have a taste for Quirmian wine, have difficulty turning down the offer of a bottle, and can be a little boring about vintages, that’s a quirk.\n\nYou may take up to five quirks at -1 point apiece . . . giving you five more points to spend. You can also “buy off” a quirk later by paying a point – although you shouldn’t, as a rule. Quirks might have a small cost, but they’re a big part of what makes a character seem “real”!",
+					"calc": {
+						"points": -36
+					}
+				},
+				{
+					"id": "32b2d505-91a0-4168-b770-866e902c3aa7",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "57998eb5-7790-4b48-92f9-68ad354c3780",
+							"type": "trait",
+							"name": "Secret (@Secret@)",
+							"reference": "DW65",
+							"userdesc": "You have a secret that you really don’t want revealed. The GM sets the point value, which can range from -5 points (exposure would be terribly embarrassing) to -30 points (run for your life or you’re dead). The GM also decides when your Secret is threatened; if in doubt, a roll of 6 or less on 3d at the start of a game session is reason enough. You should always bear this problem in mind, though – just in case. If for whatever reason your Secret is revealed, the GM will replace it with new, permanent disadvantages equal to twice its value.",
+							"modifiers": [
+								{
+									"id": "be0d3c20-c61c-49f3-ba2e-5a2b43109748",
+									"type": "modifier",
+									"name": "Serious Embarrassment",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "0fc56f73-1aad-419e-b07f-c7ca028b725a",
+									"type": "modifier",
+									"name": "Utter Rejection",
+									"cost": -10,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "00e88f4b-24f3-47c5-bdea-d27113d1a077",
+									"type": "modifier",
+									"name": "Imprisonment",
+									"cost": -20,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "d1bbcbc7-5028-453c-8728-1b004334b66a",
+									"type": "modifier",
+									"name": "Possible Death",
+									"cost": -30,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "637c5dca-43ff-4edc-85f5-8407af8845fb",
+							"type": "trait",
+							"name": "Secret Identity (@Secret ID@)",
+							"reference": "DW65",
+							"userdesc": "A “double life” is one interesting type of Secret. Such a Secret is worth an extra -10 points if you have Status 3+, because you are watched more closely – the problem comes up on a roll of 7 or less, not 6 or less – and have more to lose.",
+							"modifiers": [
+								{
+									"id": "e1aa472c-86ac-43af-9eb2-86c481c850ee",
+									"type": "modifier",
+									"name": "Serious Embarrassment",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "821b90e4-2501-464e-bd87-01b6656e6a44",
+									"type": "modifier",
+									"name": "Utter Rejection",
+									"cost": -10,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "0291e2c0-1f0f-447a-a7a0-821c3a5e9b3a",
+									"type": "modifier",
+									"name": "Imprisonment",
+									"cost": -20,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "f78a22ac-0fd0-4115-898d-e9121551ef6d",
+									"type": "modifier",
+									"name": "Possible Death",
+									"cost": -30,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"name": "Secret",
+					"userdesc": "You have a secret that you really don’t want revealed. The GM sets the point value, which can range from -5 points (exposure would be terribly embarrassing) to -30 points (run for your life or you’re dead). The GM also decides when your Secret is threatened; if in doubt, a roll of 6 or less on 3d at the start of a game session is reason enough. You should always bear this problem in mind, though – just in case. If for whatever reason your Secret is revealed, the GM will replace it with new, permanent disadvantages equal to twice its value.",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "608e2236-3706-4629-8cf4-13ff9c0dbcb9",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "7843e819-9b2e-4d99-bf01-bd748035d359",
+							"type": "trait",
+							"name": "Crippling Shyness",
+							"reference": "DW65",
+							"notes": "You avoid strangers whenever possible.",
+							"userdesc": "You may not learn the listed skills at all, and you have -4 on default rolls for them.",
+							"base_points": -20,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Acting"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Carousing"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Diplomacy"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Fast-Talk"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Intimidation"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Leadership"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Merchant"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Panhandling"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Performance"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Politics"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Public Speaking"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Savoir-Faire"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Sex Appeal"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Streetwise"
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Teaching"
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Acting"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Carousing"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Diplomacy"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Fast-Talk"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Leadership"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Merchant"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Panhandling"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Performance"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Politics"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Public Speaking"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Savoir-Faire"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Sex Appeal"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Streetwise"
+									},
+									"amount": -4
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Teaching"
+									},
+									"amount": -4
+								}
+							],
+							"calc": {
+								"points": -20
+							}
+						},
+						{
+							"id": "ef717a2a-649d-4088-87ea-439a803c08e3",
+							"type": "trait",
+							"name": "Mild Shyness",
+							"reference": "DW65",
+							"notes": "You are uneasy with strangers, especially assertive or attractive ones.",
+							"userdesc": "You have -1 on skills that require you to deal with people: Acting, Carousing, Diplomacy, Fast-Talk, Intimidation, Leadership, Merchant, Panhandling, Politics, Public Speaking, Savoir-Faire, Sex Appeal, Streetwise, and Teaching.",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Acting"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Carousing"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Diplomacy"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Fast-Talk"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Leadership"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Merchant"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Panhandling"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Performance"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Politics"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Public Speaking"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Savoir-Faire"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Sex Appeal"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Streetwise"
+									},
+									"amount": -1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Teaching"
+									},
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "65a5918a-6e73-4efe-89fb-ec9fc7e33b28",
+							"type": "trait",
+							"name": "Severe Shyness",
+							"reference": "DW65",
+							"notes": "You are very uncomfortable around strangers, and tend to be quiet even among friends.",
+							"userdesc": "You tend to be quiet even among friends, and you have -2 to the above skills.",
+							"base_points": -10,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Acting"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Carousing"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Diplomacy"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Fast-Talk"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Leadership"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Merchant"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Panhandling"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Performance"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Politics"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Public Speaking"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Savoir-Faire"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Sex Appeal"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Streetwise"
+									},
+									"amount": -2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Teaching"
+									},
+									"amount": -2
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						}
+					],
+					"name": "Shyness",
+					"userdesc": "You’re uncomfortable around strangers. Roleplay it! This disadvantage comes in three levels:",
+					"calc": {
+						"points": -35
+					}
+				},
+				{
+					"id": "f2cccae4-4c35-4804-8acf-9b131bdcdf84",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "f812c9dd-51bb-400c-847f-c3901ecaf7f1",
+							"type": "trait",
+							"name": "No Sense of Humour",
+							"reference": "DW65",
+							"userdesc": "You never get jokes, think everyone is earnestly serious at all times, and never joke yourself. Others react to you at -2 when they notice.",
+							"base_points": -10,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others in any situation where No Sense of Humor becomes evident",
+									"amount": -2
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "3114e594-9586-42af-90c4-8a7d1378cc58",
+							"type": "trait",
+							"name": "Selfish",
+							"reference": "DW65",
+							"notes": "Make a self-control roll whenever you experience a clear social slight or “snub.” On a failure, you lash out at the offending party just as if you had Bad Temper.",
+							"userdesc": "You’re self-important and status-conscious, spending much of your time striving for social dominance. Make a selfcontrol roll whenever you experience a social slight or snub. Failure means you lash out at the offending party as if you had Bad Temper (p. 64), giving -3 to the target’s reactions toward you. Selfish NPCs react to perceived slights at -2 if their self-control number is 15, -3 if it’s 12, -4 if it’s 9, or -5 if it’s 6.",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others when your Selfishness surfaces",
+									"amount": -3
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "747f2e9c-bbff-4d84-a4c0-a5a28e72868a",
+							"type": "trait",
+							"name": "Stubbornness",
+							"reference": "DW65",
+							"userdesc": "You always want your own way. Your friends have to make a lot of Fast-Talk rolls to get you to go along with reasonable plans. Others react to you at -1 when they notice",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others when they notice",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": -5
+							}
+						}
+					],
+					"name": "Unsociable Flaws",
+					"userdesc": "These problems make you hard to live with. Roleplay them!",
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "adbea7ff-066c-4434-8e8b-356def965d00",
+					"type": "trait_container",
+					"children": [
+						{
+							"id": "7de5f511-500a-4200-bcd4-8b1c182101b3",
+							"type": "trait",
+							"name": "Charitable",
+							"reference": "DW65",
+							"notes": "Make a self-control roll in any situation where you could render aid or are specifically asked for help, but should resist the urge",
+							"userdesc": "You are acutely aware of others’ emotions and feel compelled to help those around you – even legitimate enemies. Make a self-control roll in any situation where you could render aid or are specifically asked for help, but should resist the urge. If you fail, you must offer assistance, even if that means violating orders or walking into a potential trap.",
+							"base_points": -15,
+							"cr": 12,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "c8a5a7a7-8c83-479d-bf06-6fb314559769",
+							"type": "trait",
+							"name": "Honesty",
+							"reference": "DW66",
+							"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
+							"userdesc": "You must obey the law and do your best to get others to do so, too. In areas with little or no law, you don’t “go wild” – you act as though the laws of your own home were in force. You also assume that others are honest unless you know otherwise. Make a self-control roll when faced with unreasonable laws; if you fail, you must obey them, whatever the consequences. If you resist your urges and break the law, make a second self-control roll afterwards. Failure means you must turn yourself in to the authorities! -",
+							"base_points": -10,
+							"cr": 12,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "5118fd32-95e5-4d94-ba03-3eed52ee6d08",
+							"type": "trait",
+							"name": "Selfless",
+							"reference": "DW66",
+							"notes": "You must make a self-control roll to put your needs – even survival – before those of someone else.",
+							"userdesc": "You’re deeply altruistic and self-sacrificing. You must make a self-control roll to put your needs – even survival – before those of someone else.",
+							"base_points": -5,
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "6b2fc2b1-9aa3-4c18-84bd-69bf6ded4c3e",
+							"type": "trait",
+							"name": "Truthfulness",
+							"reference": "DW66",
+							"notes": "Make a self-control roll whenever you must keep silent about an uncomfortable truth (lying by omission). Roll at -5 if you actually have to tell a falsehood! If you fail, you blurt out the truth, or stumble so much that your lie is obvious.",
+							"userdesc": "You hate to tell a lie, or are just very bad at it. Make a self-control roll whenever you must keep silent about an uncomfortable truth (lying by omission); this is at -5 if you actually have to tell a falsehood! Failure means you blurt out the truth, or stumble so much that your lie is obvious. You have a permanent -5 to Fast-Talk skill, and your Acting skill is at -5 when your purpose is to deceive.",
+							"base_points": -5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fast-talk"
+									},
+									"amount": -5
+								}
+							],
+							"cr": 12,
+							"calc": {
+								"points": -5
+							}
+						}
+					],
+					"name": "Virtuous Flaws",
+					"userdesc": "A few traits often regarded as virtues are considered disadvantages because they severely limit your options:",
+					"calc": {
+						"points": -35
+					}
+				},
+				{
+					"id": "bdfb3d5a-96a4-44fb-ae49-44b2fa1bef5b",
+					"type": "trait",
+					"name": "Absent-Mindedness",
+					"reference": "DW54",
+					"notes": "Once adrift in your own thoughts, you must roll against Perception-5 in order to notice any event short of personal physical injury",
+					"userdesc": "You have trouble focussing on anything not of immediate interest. You have -5 on IQ and IQ-based skill rolls except for the task on which you’re currently concentrating. If no engaging topic presents itself, you’ll ignore your immediate surroundings until something brings you back. Once adrift, you must roll against Perception at -5 to notice anything short of personal injury. You may attempt to rivet your attention on a boring topic (small talk, guard duty, driving a cart down a straight highway, etc.) by making a Will-5 roll once every five minutes.\n\nAlso, the GM may call for an IQ-2 roll for you to remember to do something small but significant, such as reloading your crossbow after firing it.",
+					"base_points": -15,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all IQ and IQ-based skill rolls, save those for the task you are currently concentrating on",
+							"amount": -5
+						}
+					],
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "fab3053f-8f50-4df3-9417-11939f36d3f4",
+					"type": "trait",
+					"name": "Addiction (@Substance@)",
+					"reference": "DW54",
+					"userdesc": "You’re addicted to a drug. A habit which is legal, costs no more than a few pence a day, leaves you generally functional, and can be suppressed fairly easily – for instance, light smoking or caffeine addiction – is merely a quirk (p. 66). Some addictions are more severe, however. Disadvantage value depends on the particulars:\n\nCost: If your habit is expensive, costing you $0.20-$0.50 per day, that’s worth -5 points. If it’s very expensive, costing dollars per day, that’s worth -15 points. \n\nLegality: If the drug is illegal, that’s worth -5 points. 1\n\nAddictiveness: If you can’t get hold of your drug, you must make Will or HT rolls to avoid problems (see Withdrawal, below). If it’s highly addictive, these are at -5, which is worth an extra -5 points. Totally addictive drugs give -10 and are worth an extra -10 points.\n\nExtreme Effects: A drug that renders you unconscious or “blissed out” for a couple of hours a day, that makes you hallucinate blue elephants or talk to gods who aren’t actually there, or that will make your head explode if you don’t come off it within the year, is worth an extra -10 points.\n\nDrugs that lack extreme effects still have some consequences,\nperhaps making the user feel energised for an hour or two (roleplay this!) . . . until they wear off. After drugs wear off, addicts are\noften depressed and irritable for a while (roleplay that, too).",
+					"modifiers": [
+						{
+							"id": "fbd5a34a-8756-4d14-a5af-2c06348aa54e",
+							"type": "modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "8c2a3142-a939-4004-ad5d-499ae6fa3566",
+									"type": "modifier",
+									"name": "Expensive",
+									"notes": "@$0.20-$0.50@ per day",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "892bb52a-362e-4a90-bc6a-72127afbe150",
+									"type": "modifier",
+									"name": "Very Expensive",
+									"notes": "@Dollars@ per day",
+									"cost": -15,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"name": "Cost"
+						},
+						{
+							"id": "111b11c6-e991-46d2-81d4-f76210fd5b23",
+							"type": "modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "7b7bbaee-545a-4860-bbf7-c5b1b4675ca1",
+									"type": "modifier",
+									"name": "Illegal",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"name": "Legality"
+						},
+						{
+							"id": "3e262c1b-be0f-4db7-8771-7b4dfdaac90c",
+							"type": "modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "0ef02da7-a1ec-4f5d-814a-c2770b79ead0",
+									"type": "modifier",
+									"name": "Highly Addictive (-5 on withdrawal roll)",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "bcf905ae-5148-48e8-8842-1b5b342a276d",
+									"type": "modifier",
+									"name": "Totally Addictive (-10 on withdrawal roll)",
+									"cost": -10,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"name": "Addictiveness"
+						},
+						{
+							"id": "4e05c404-a365-4841-a5e3-1841bb3581ca",
+							"type": "modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "9d544143-e3b7-4eaa-8cdb-d6c856158971",
+									"type": "modifier",
+									"name": "Hallucinogenic",
+									"cost": -10,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "90ed43c8-dad6-4c78-bf22-cf13846b6489",
+									"type": "modifier",
+									"name": "Incapacitating",
+									"cost": -10,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"name": "Effect Modifiers"
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "a20e2368-c45a-48f3-b439-92ebde66ed19",
+					"type": "trait",
+					"name": "Alcoholism",
+					"reference": "DW54",
+					"notes": "Resist on Will+4",
+					"userdesc": "Alcoholism uses the Addiction rules (above). Being cheap, incapacitating, and usually legal, it would normally be a -10-point Addiction. However, it’s also insidious, so it’s worth -15 points.\n\nMost of the time, you may confine your drinking to the evenings, and therefore function normally for many purposes. However, any time you’re in the presence of alcohol, you must roll vs. Will to avoid partaking (treat Will 14+ as 13 for this purpose). Failure means you go on a binge lasting 2d hours, probably followed by a hangover; see Drinking (pp. 187-188). Binging Alcoholics will go very quickly to being fully drunk, and are prone to sudden, extreme mood swings between friendliness and hostility.\n\nIt might seem that alcoholics with high HT and Will won’t suffer much. However, being able to handle more booze with less effect simply causes an alcoholic to drink more. High-HT alcoholics spend a lot on booze – and still frequently end up incapacitated or annoying in the evenings or when they binge.\n\nContinued alcoholism destroys your abilities. Roll yearly against HT+2. Failure means you lose a level from one of your four basic attributes; roll randomly to determine which.",
+					"modifiers": [
+						{
+							"id": "c8f54d0b-0648-480e-909d-078e87c25a9a",
+							"type": "modifier",
+							"name": "Withdrawn",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"base_points": -15,
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "18be2e88-b54b-468f-b326-f892a029ba87",
+					"type": "trait",
+					"name": "Bad Back",
+					"reference": "DW55",
+					"notes": "Throw out your back whenever you make a ST roll, and whenever you roll 17 or 18 on an attack or defense roll in melee combat, or on a roll for an “athletic” skill such as Acrobatics, make a HT roll as well",
+					"userdesc": "Your spine is in bad shape. This may be Mild (-15 points) or Severe (-25 points). Whenever you miss a roll against a movement skill (pp. 78-79), fail an attack or defence roll in melee by 3 or more, or critically fail such a roll, and any time you must attempt a ST roll, make a HT roll as well. This is at -2 if your problem is Severe. Any modifiers to the roll that triggered the problem apply here, too.\n\nFailure means you throw your back. Until someone helps you by making a First Aid roll at -2, or you lie down and rest for an hour, you’ll suffer problems. The consequences depend on the severity of your case:\n\nMild: You’re at -3 DX – and at -3 IQ during the second after your back goes (on your next turn, in combat). Critical failure means you’re at -5 DX and must make a Will roll to perform any physical action.\n\nSevere: Your DX and IQ are both at -4 for the duration. Critical failure means your muscles lock up completely, leaving you like a statue.\n\nHigh Pain Threshold (p. 43) halves all DX and IQ penalties (drop fractions).\n\nIf you have enough bonus character points (p. 219) to buy off this problem, you may choose to do so immediately after someone succeeds at that First Aid-2 roll, for comic effect. Roleplay your gratitude!",
+					"modifiers": [
+						{
+							"id": "42d07232-2402-4a80-909e-47679015ba3a",
+							"type": "modifier",
+							"name": "Severe",
+							"notes": "The HT roll is at -2",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "on DX and IQ the second after your back goes out",
+									"amount": -4
+								}
+							]
+						}
+					],
+					"base_points": -15,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on DX and IQ the second after your back goes out",
+							"amount": -3
+						}
+					],
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "7bd0646d-5ff7-4779-8309-a8d9fdb74c7d",
+					"type": "trait",
+					"name": "Bad Smell",
+					"reference": "DW55",
+					"userdesc": "You exude an appalling odour that you cannot remove, such as the stench of decay. This causes a -2 reaction from most people and animals (although pests or carrion-eating scavengers might be attracted). You can mask the smell with perfume, but the amount needed results in the same reaction penalty.",
+					"base_points": -10,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from most people and animals (although pests or carrion-eating scavengers might be attracted to you!)",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "7552100d-7408-4d9b-aee4-361313b4e87f",
+					"type": "trait",
+					"name": "Berserk",
+					"reference": "DW55",
+					"notes": "Make a self-control roll any time you suffer damage over 1/4 your HP in the space of one second, and whenever you witness equivalent harm to a loved one",
+					"userdesc": "You tend to run amok when you or a loved one is harmed, attacking whatever you see as the cause of the trouble. Make a self-control roll any time you suffer injury over 1/4 of your HP in the space of one second, and whenever you witness equivalent harm to a loved one. Failure means you go berserk. You go berserk automatically if you fail a self-control roll for Bad Temper (p. 64)!\n\nWhile berserk, you make All-Out Attacks (p. 175) and never bother to Aim (p. 175). If you run out of ammunition for a ranged weapon, you either draw another weapon or charge into melee. You’re immune to stunning and shock, and injuries cause no penalty to your Move score. You make HT rolls to remain conscious or alive at +4. If you don’t fail any rolls, you remain alive and madly attacking until you reach -5¥HP. Then you fall dead.\n\nWhenever you down an opponent, you may (if you wish) attempt another self-control roll. If you fail (or don’t roll), you continue to the next foe. Treat any friend who attempts to restrain you as a foe. You get one extra roll when no more enemies remain; if you’re still berserk, you start to attack your friends. Once you snap out of the berserk state, all your wounds immediately affect you. Roll at normal HT to see whether you remain conscious and alive.",
+					"base_points": -10,
+					"cr": 12,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "4f768a63-f910-480e-a52e-c26811674160",
+					"type": "trait",
+					"name": "Blindness",
+					"reference": "DW55",
+					"notes": "Cannot target hit locations",
+					"userdesc": "You cannot see at all. In unfamiliar territory, you must travel slowly and carefully, or have a companion or a guide animal lead you. You’re at -6 to all combat skills. You can make melee attacks, but you cannot target a particular hit location. With a ranged weapon, you can only attack randomly, or engage targets so close that you can hear them. Many other actions are impossible for you.\n\nAll this assumes that you’re accustomed to blindness. Someone who suddenly loses his eyesight fights at -10, just as if he were in total darkness.\n\nThis isn’t an easy disadvantage to buy off with bonus character points, but a very few blind witches have refocused their precognitive powers onto the present.",
+					"base_points": -50,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"tags": {
+								"compare": "contains",
+								"qualifier": "combat"
+							},
+							"amount": -6
+						}
+					],
+					"calc": {
+						"points": -50
+					}
+				},
+				{
+					"id": "ba4e5fde-6679-404c-93b4-9b5337add530",
+					"type": "trait",
+					"name": "Callous",
+					"reference": "DW56",
+					"userdesc": "You are merciless. You can decipher others’ emotions, but do so only to manipulate people. This gives you -3 to Teaching skill, on Psychology rolls made to help others (as opposed to deduce weaknesses), and on any skill roll made to interact with those who’ve previously suffered from your callousness. Past victims react to you at -1, as does anyone with Empathy. However, you do get an extra +1 to Interrogation and Intimidation rolls when you use threats or torture.",
+					"base_points": -5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "psychology"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "teaching"
+							},
+							"amount": -3
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from past victims and anyone with Empathy",
+							"amount": -1
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to Interrogation and Intimidation rolls when you use threats or torture",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "2afc7cef-9777-4fe7-94e4-384ceddb377b",
+					"type": "trait",
+					"name": "Chummy",
+					"reference": "DW56",
+					"userdesc": "You much prefer company to being alone. This comes in two levels:\n\nChummy: When alone, you’re unhappy and distracted: -1 to IQ-based skills. Chummy NPCs usually react to others at +2.  \n\nGregarious: You’re miserable when alone: -2 to IQ-based skills – or -1 if in a group of four or less. Gregarious NPCs usually react to others at +4. ",
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "to others",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to IQ-based skills when alone",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "563265c0-a355-4f5f-8889-44c19752d46c",
+					"type": "trait",
+					"name": "Combat Paralysis",
+					"reference": "DW57",
+					"notes": "In any situation in which personal harm seems imminent, make a HT roll. Do not roll until the instant you need to fight, run, pull the trigger, or whatever. Any roll over 13 is a failure, even if you have HT 14+. On a success, you can act normally. On a failure, you are mentally stunned. ",
+					"userdesc": "You “freeze up” in combat situations and receive -2 to all Fright Checks. This has nothing to do with Cowardice (p. 64); you might be brave, but your body betrays you. Conversely, a coward may respond very promptly to danger – by running away!\n\nIn any situation in which personal harm seems imminent, make a HT roll. Don’t roll until the instant you need to fight, run, pull the trigger, or whatever. Any roll over 13 is a failure, even if you have HT 14+. Success lets you act normally. Failure means you’re mentally stunned (see Mental Stunning, p. 171); make another HT roll every second, at a cumulative +1 per turn after the first, to break the freeze. A quick slap from a friend gives +1 to your cumulative roll.\n\nOnce you unfreeze, you won’t freeze again until the immediate danger is over. Then, in the next dangerous situation, you may freeze once again.\n\nThis is the opposite of Combat Reflexes (p. 42). You cannot have both.",
+					"base_points": -15,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Combat Reflexes"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "91b86869-3333-4a41-a359-3ab60a706ab9",
+					"type": "trait",
+					"name": "Deafness",
+					"reference": "DW59",
+					"userdesc": "You cannot hear anything. You must receive information in writing (if you’re literate) or sign language, and you won’t hear that runaway cart careering down the street toward your back . . .",
+					"base_points": -20,
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "d1d8a8b0-281f-4de6-a697-324c54580284",
+					"type": "trait",
+					"name": "Delusion (@Belief@)",
+					"reference": "DW59",
+					"userdesc": "You believe something that simply isn’t true. Other people may consider you insane – and they may be right! You must roleplay your belief at all times. Point value depends on the Delusion’s nature:\n\nMinor Delusions affect your behaviour. They don’t keep you from functioning more-orless normally, but anyone around you will soon notice them and react to you at -1. -5 points.\n\nMajor Delusions have a strong effect on your behaviour. While they still don’t keep you from living a fairly normal life, others react at -2. -10 points.\n\nSevere Delusions influence your behaviour so severely that they may keep you from functioning in the everyday world. Others react at -3, but are more likely to fear or pity you than to attack. -15 points.\n\nTwo specific examples:\n\nMegalomania: The Major Delusion that you’re destined for greatness. Choose some grand goal, and let nothing stand between you and destiny! Young or naïve characters, and fanatics looking for a new cause, may actually react to you at +2; others react at the usual penalty.\n\nParanoia: The Major Delusion that everyone is plotting against you. You trust no one except old friends – and you keep an eye on them. Paranoid NPCs react at -4 to any stranger, and double any “legitimate” reaction penalty (e.g., for an unfriendly nationality).\n\nTwo other, tragically common Major Delusions are “My combat sports training is fully effective in a real fight” and “My superior social class automatically makes me a good warrior.” The latter requires Status 1+, is usually associated with Status 3+, and isn’t allowed to anyone who’s genuinely competent in a fight. These are slightly unusual in that neither tends to earn reaction penalties – except from veteran warriors who know what sort of mess they cause – and neither is much of a disadvantage outside combat. They just get sufferers killed, a lot; the second unfortunately also gets people serving under the sufferer killed.",
+					"modifiers": [
+						{
+							"id": "ac2f3661-107e-4425-a132-9d90df099e7c",
+							"type": "modifier",
+							"name": "Minor",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "aecc1c19-74f1-4379-b1e9-baed32ec4088",
+							"type": "modifier",
+							"name": "Major",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "dbb776b3-9d95-4203-8e0c-9d500dae7615",
+							"type": "modifier",
+							"name": "Severe",
+							"cost": -15,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "a51b9bc7-7e1b-43af-8022-4b119fa286c0",
+					"type": "trait",
+					"name": "Duty (@Duty@)",
+					"reference": "DW59",
+					"userdesc": "You have an official responsibility to a cause or an organisation, and can’t easily avoid it. Most ordinary jobs don’t qualify – a real Duty is likely to be hazardous and often inconvenient. Military service, however, is often both a job and a Duty.\n\nThe GM rolls at the beginning of each adventure to see whether your Duty comes into play. Being “called to duty” could delay your plans, or be the reason for the adventure – or your master might give you a secret agenda to pursue.\n\nA Duty’s basic point value depends on the frequency with which it arises in play:\n\nModify base cost if the Duty is more or less dangerous than average:\n\nExtremely Hazardous: You’re always at risk of death or serious injury when your Duty comes up. -5 points.\n\nNonhazardous: Your Duty never requires you to risk your life. (This can raise the cost to 0 points or more; if so, the obligation is too trivial to qualify.) +5 points.",
+					"modifiers": [
+						{
+							"id": "395d25bc-3345-4932-939b-47f0d712b717",
+							"type": "modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "d6406b89-6289-4b8c-b7c7-4d25add3c352",
+									"type": "modifier",
+									"name": "FR: 15",
+									"cost": -15,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "80577150-cbdb-4c26-bde4-1ad85a7deec2",
+									"type": "modifier",
+									"name": "FR: 12",
+									"cost": -10,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "92ade39a-a64c-4ff4-a84b-89ab92a6e217",
+									"type": "modifier",
+									"name": "FR: 9",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "fb0c80a4-4c65-4521-9e18-7378dda34a46",
+									"type": "modifier",
+									"name": "FR: 6",
+									"cost": -2,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"name": "Frequency"
+						},
+						{
+							"id": "023791ad-a3b9-4705-8f7a-b5c8e8f369c4",
+							"type": "modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "f4458d02-9b67-42f8-8f31-5837064fb751",
+									"type": "modifier",
+									"name": "Extremely Hazardous",
+									"cost": -5,
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "5d87b90f-fc68-4d78-8547-7c2ef58ae7bd",
+									"type": "modifier",
+									"name": "Nonhazardous",
+									"cost": 5,
+									"cost_type": "points",
+									"disabled": true
+								}
+							],
+							"name": "Danger"
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "194ea776-c4a7-400c-86b6-41713faf4da5",
+					"type": "trait",
+					"name": "Easy to Read",
+					"reference": "DW60",
+					"userdesc": "Your body language betrays your intentions. This is not the same as Truthfulness (p. 66). You have no moral problem with lying, and may possess Fast-Talk at a high level, but your face or stance gives the game away.\n\nEasy to Read gives others +4 on all Empathy, Body Language, and Psychology rolls to discern your intentions or the truth of your words, and +4 to their IQ, Detect Lies, and Gambling rolls in any Quick Contest with your Acting, Fast-Talk, or Gambling skill when you try to lie or bluff.\n\nThis is a mental disadvantage, despite its physical manifestations. With enough practise, you can “buy it off.”",
+					"base_points": -10,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to others on all Empathy, Body Language, and Psychology rolls to discern your intentions or the truth of your words",
+							"amount": 4
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to others on IQ, Detect Lies, and Gambling rolls in any Quick Contest with your Acting, Fast-Talk, or Gambling skill when you try to lie or bluff",
+							"amount": 4
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "5f0b9a88-4f99-4a46-9bac-56f2b8c02873",
+					"type": "trait",
+					"name": "Fearfulness",
+					"reference": "DW60",
+					"userdesc": "Fearfulness gives -1 per level to Will whenever you must make a Fright Check (pp. 170-171) or resist Intimidation (p. 74), and +1 per level to all Intimidation rolls made against you. You may not reduce your Will roll below 3; e.g., if you have Will 11, you’re limited to Fearfulness 8.",
+					"levels": 1,
+					"points_per_level": -2,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "fearlessness"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "to all Intimidation rolls make against you",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": -2
+					}
+				},
+				{
+					"id": "da676ff7-999d-406e-9ea7-241f1c04bc22",
+					"type": "trait",
+					"name": "Gullibility",
+					"reference": "DW60",
+					"userdesc": "There’s one born every minute, and you’re it. You’ll swallow even the most ridiculous story if it’s told with conviction. Whenever you’re confronted with a lie – or an improbable truth, for that matter – make a self-control roll, modified for the story’s plausibility. Failure means you believe what you were told.\n\nAs well, you’re at -3 (to IQ, skills, etc.) in any situation in which your credulity might be exploited. This includes all Merchant skill rolls. You can never learn the Detect Lies skill.",
+					"base_points": -10,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "detect lies"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "merchant"
+							},
+							"amount": -3
+						}
+					],
+					"cr": 12,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "df12c218-8dba-4c61-b85a-a060980e2e88",
+					"type": "trait",
+					"name": "Ham-Fisted",
+					"reference": "DW60",
+					"userdesc": "You have poor fine motor skills and suffer -3 on rolls for any kind of small-detail work. You also tend to be badly groomed and messy, giving -1 to reaction rolls when this matters.",
+					"levels": 1,
+					"points_per_level": -5,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "high manual dexterity"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "artist"
+							},
+							"amount": -3,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "jeweler"
+							},
+							"amount": -3,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "knot-tying"
+							},
+							"amount": -3,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "leatherworking"
+							},
+							"amount": -3,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "lockpicking"
+							},
+							"amount": -3,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "pickpocket"
+							},
+							"amount": -3,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sewing"
+							},
+							"amount": -3,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sleight of hand"
+							},
+							"amount": -3,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "surgery"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "machinist"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "mechanic"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "fast-draw"
+							},
+							"amount": -3
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from others where being tidy or well-groomed would matter",
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "to any Influence roll where being tidy or well-groomed would matter",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "67129ffb-72af-4aaa-ad0d-2f941be5e870",
+					"type": "trait",
+					"name": "Innumerate",
+					"reference": "DW60",
+					"userdesc": "You have little or no grasp of mathematics. You cannot learn – and get no default with – Computer Programming or any of the skills that benefit from Mathematical Ability (p. 47). This has many frustrating side-effects: you must use your fingers to count or perform arithmetic, and you’re easily cheated by dishonest merchants (-4 to rolls to notice you’ve been had).",
+					"base_points": -5,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "contains",
+									"qualifier": "physics"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "contains",
+									"qualifier": "mathematics"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "market analysis"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "finance"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "contains",
+									"qualifier": "engineer"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "cryptography"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "astronomy"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "accounting"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "economics"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "computer programming"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to rolls to notice you've been cheated by dishonest merchants",
+							"amount": -4
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "e81630f6-a511-4e74-8e9a-e94c3786cf00",
+					"type": "trait",
+					"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+					"reference": "DW60",
+					"userdesc": "You dislike and distrust some or all people who are different from you. You may be prejudiced on the basis of class, species, nationality, religion, or sex. Roleplay this! (An NPC with Intolerance reacts at -3 to the hated group.) Victims of your Intolerance will return the favour, reacting to you at -1 to -5 (GM’s decision).\n\nPoint value depends on the scope of your Intolerance. Total Intolerance of anyone not of your own class, species, nationality, or religion (pick one) is a -10-point disadvantage. Intolerance directed at one specific class, species, nationality, religion, or sex is worth from -5 points for a commonly encountered victim to -1 point (a nasty quirk) for a rare victim.\n\nJealousy is Intolerance of anyone who seems smarter, more attractive, or better off than you! This is worth -10 points, because it often affects you very badly. You resist any plan proposed by such a “rival,” and hate it if someone else is in the limelight.",
+					"modifiers": [
+						{
+							"id": "0e1c693c-166b-417f-b6aa-1c6e04afbd68",
+							"type": "modifier",
+							"name": "Scope: Common",
+							"reference": "B140",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "e21c80e8-cdd8-4040-b7a1-33af63210703",
+							"type": "modifier",
+							"name": "Scope: Occasional",
+							"reference": "B140",
+							"cost": -2,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "2655dfad-4f5e-4367-a524-fad35a774654",
+							"type": "modifier",
+							"name": "Scope: Rare",
+							"reference": "B140",
+							"cost": -1,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "522dbb89-3781-4d8b-bf72-a6d24892dce2",
+							"type": "modifier",
+							"name": "Scope: Anyone unlike you",
+							"reference": "B140",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "6430e5f7-9d42-4996-89e9-ac70f8395bdd",
+					"type": "trait",
+					"name": "Klutz",
+					"reference": "DW60",
+					"userdesc": "You have a talent for physical blunders. You cannot have DX higher than 13, and you must make a DX roll to get through the day without at least one annoying or embarrassing accident. Avoid laboratories, explosives, and china shops!",
+					"base_points": -5,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "attribute_prereq",
+								"has": true,
+								"qualifier": {
+									"compare": "at_most",
+									"qualifier": 13
+								},
+								"which": "dx"
+							}
+						]
+					},
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "f317ee06-1443-44c0-a766-30f4d33c0e0e",
+					"type": "trait",
+					"name": "Laziness",
+					"reference": "DW61",
+					"notes": "Your chances of getting a raise or promotion in any job are halved. If you are self-employed, halve your monthly pay.",
+					"userdesc": "You’re violently averse to work, especially physical labour. Your chances of getting a raise or promotion in any job are halved. If you’re self-employed, halve your monthly pay. Roleplay it!",
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "b15b2abd-b5ea-485a-a35c-f44dc6fcd73b",
+					"type": "trait",
+					"name": "Low Pain Threshold",
+					"reference": "DW61",
+					"notes": "Double the shock from any injury. Whenever you take a wound that does more than 1 HP of damage, you must make a Will roll to avoid crying out.",
+					"userdesc": "You’re very sensitive to pain. Double the shock from any injury; e.g., if wounded for 3 HP, you’re at -6 to DX and IQ on your next turn. Also, you roll at -4 to resist knockdown, physical stunning, and physical torture. Whenever you suffer a wound that inflicts more than 1 HP of injury, you must make a Will roll to avoid crying out. Failure can give away your presence and earn -1 to reactions from “macho” individuals.",
+					"base_points": -10,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "high pain threshold"
+								}
+							}
+						]
+					},
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from \"macho\" individuals",
+							"amount": -1
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to resist knockdown, stunning, and physical torture",
+							"amount": -4
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "6d9afd9f-27d9-4995-ab23-7d17bc212de4",
+					"type": "trait",
+					"name": "Miserliness",
+					"reference": "DW62",
+					"notes": "Make a self-control roll any time you are called on to spend money. If the expenditure is large, this roll may be at -5 or worse (GM’s decision). If you fail, you refuse to spend the money.",
+					"userdesc": "You must always hunt for the best deal possible. Make a selfcontrol roll any time you’re called on to spend money; the GM may penalise your roll for large expenditures. Failure means you refuse to spend. If you absolutely must spend the money, you haggle and complain interminably",
+					"base_points": -10,
+					"cr": 12,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "c6423857-c724-4b70-964b-ddad69a762e3",
+					"type": "trait",
+					"name": "Overconfidence",
+					"reference": "DW62",
+					"notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+					"userdesc": "You believe that you’re far more powerful, intelligent, or competent than you really are. You might be proud and boastful, or just quietly determined, but you must roleplay this! The GM may request a self-control roll any time he feels you show an unreasonable degree of caution. Failure means you must go ahead as though you were able to handle the situation. \n\nYou receive +2 on reaction rolls from young or naïve individuals (who believe you are that good), but -2 on reactions from experienced NPCs.",
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from young or naive individuals who believe you are as good as you say you are",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from experienced NPCs",
+							"amount": -2
+						}
+					],
+					"cr": 12,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "87423057-5100-4b49-b681-ad62c24c2438",
+					"type": "trait",
+					"name": "Pyromania",
+					"reference": "DW64",
+					"notes": "Make a self-control roll whenever you have an opportunity to set a fire",
+					"userdesc": "You like fires! You like to set fires, too; make a self-control roll whenever you have the opportunity. For good roleplaying, you should never miss a chance to employ fire, or to appreciate one you encounter.",
+					"base_points": -5,
+					"cr": 12,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "9ad963ce-d163-4619-beb2-13a2e504e327",
+					"type": "trait",
+					"name": "Post-Combat Shakes",
+					"reference": "DW64",
+					"notes": "Make a self-control roll at the end of any battle. If you fail, roll 3d, add the amount by which you failed your self-control roll, and look up the result on the Fright Check Table.",
+					"userdesc": "You’re shaken and sickened by combat, but only after it’s over. Make a self-control roll at the end of any fight. It’s up to the GM to determine when combat has truly ended, and he may apply a penalty if it was particularly dangerous or gruesome. If you fail, roll 3d, add the amount by which you failed your self-control roll, and look up the result on the Fright Check Table (pp. 170-171). For instance, if your self-control number is 12 but you rolled a 14, roll 3d+2 on the table. This result affects you immediately!",
+					"base_points": -5,
+					"cr": 12,
+					"cr_adj": "fright_check_penalty",
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "400364f3-3d6f-4a06-b75b-69c0b0f9a6e1",
+					"type": "trait",
+					"name": "Sense of Duty",
+					"reference": "DW65",
+					"userdesc": "You feel a strong commitment toward a particular class of people. You’ll never betray them, abandon them when they’re in trouble, or let them suffer or go hungry if you can help it. This isn’t the same as an externally imposed Duty (pp. 59-60); it comes from within. Point value depends on how large a group you look out for:",
+					"modifiers": [
+						{
+							"id": "89ec98d8-237b-4ab6-82e5-f9767592c065",
+							"type": "modifier",
+							"name": "@Individual@",
+							"cost": -2,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "8fde1c7b-7271-4b9b-9032-8551dde325a8",
+							"type": "modifier",
+							"name": "@Small Group@",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "0daad494-07fe-4b61-a1fe-ab5e198b6411",
+							"type": "modifier",
+							"name": "@Large Group@",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "103f5c35-d3d6-4f0f-9336-447062d5c050",
+							"type": "modifier",
+							"name": "@Entire Race@",
+							"cost": -15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "721ee069-0e87-46c8-9638-0f2dee3142e6",
+							"type": "modifier",
+							"name": "Every Living Being",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "c558b42c-c2ea-43db-a4c5-ad919785ce08",
+					"type": "trait",
+					"name": "Short Attention Span",
+					"reference": "DW65",
+					"notes": "Make a self-control roll whenever you must maintain interest in something for an extended period of time, or whenever a distraction is offered. If you fail, you automatically fail at the task at hand.",
+					"userdesc": "You find it difficult to concentrate on a single task for longer than a few minutes. Make a self-control roll whenever you must maintain interest in something for an extended period of time, or whenever a distraction is offered. If you fail, you automatically fail at the task at hand. The GM might give you a small bonus to the self-control roll in situations where, say, your survival is at stake.",
+					"base_points": -10,
+					"cr": 12,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "710874d0-e29c-425f-933b-b6eb6c7ccb5b",
+					"type": "trait",
+					"name": "Vow",
+					"reference": "DW66",
+					"notes": "@Subject@",
+					"userdesc": "You’ve seriously sworn to do (or not do) something. Point value depends on the inconvenience this causes; the GM is the final judge. Examples: \n\nMinor Vow: Silence during daylight hours; vegetarianism; chastity (yes, for game purposes, this is minor). -5 points. \n\nMajor Vow: Use no edged weapons; keep silence at all times; own no more than you can carry with you. -10 points. \n\nGreat Vow: Never refuse any request for aid; always fight with the wrong hand; hunt a certain dangerous foe until you destroy him. -15 points.",
+					"modifiers": [
+						{
+							"id": "b86c5f36-bb6b-44b9-80c2-7ec8d2946da6",
+							"type": "modifier",
+							"name": "Minor",
+							"reference": "B161",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "9140caed-80fb-42d8-bd78-4dd02a1d5503",
+							"type": "modifier",
+							"name": "Major",
+							"reference": "B161",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "41f6d00c-96f0-4d02-930d-8d793808461b",
+							"type": "modifier",
+							"name": "Great",
+							"reference": "B161",
+							"cost": -15,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "f33c7414-99e7-4dcf-88d4-299f744fbc57",
+					"type": "trait",
+					"name": "Unluckiness",
+					"reference": "DW65",
+					"notes": "Once per play session, the GM will arbitrarily and maliciously make something go wrong for you.",
+					"userdesc": "Things go badly for you – persistently. Once per play session, the GM will arbitrarily and maliciously make something go wrong for you: you miss a vital dice roll, the enemy shows up at the worst possible time, etc. If the adventure’s plot calls for something bad to happen to someone, it’s you. The GM may not kill you outright with “bad luck,” but anything less is fine.",
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				}
+			],
+			"name": "Disadvantage",
+			"calc": {
+				"points": -1208
+			}
+		}
+	]
+}


### PR DESCRIPTION
This the information from pg. 26 to 68. there may me a few errors so keep an eye out for them.
I added Magic Points as a default attribute to my GCS settings. I plan on creating a default character sheet for Discworld RPG later to make it easier for future users. 